### PR TITLE
CMOS-26: Fix microlith build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This software uses the following components with their associated licensing also
 * Fluent Bit: Apache 2.0 https://github.com/fluent/fluent-bit/blob/master/LICENSE
 * Jaeger: Apache 2.0 https://github.com/jaegertracing/jaeger/blob/master/LICENSE
 * Nginx: https://github.com/nginxinc/docker-nginx/blob/master/LICENSE
-* Prometheus Merge Too: Apache 2.0 https://github.com/lablabs/prometheus-alert-overrider/blob/master/LICENSE
+* Prometheus Merge Tool: Apache 2.0 https://github.com/lablabs/prometheus-alert-overrider/blob/master/LICENSE
 * Couchbase Cluster Monitor: Proprietary to Couchbase https://github.com/couchbaselabs/cbmultimanager/blob/master/LICENSE
 
 Nginx is used as the base image for the microlith container.

--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -36,7 +36,6 @@ RUN git rev-parse HEAD > /etc/couchbase/git-commit.txt
 RUN go mod download && \
     CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbmultimanager ./cluster-monitor/cmd/cbmultimanager && \
     CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbeventlog ./cluster-monitor/cmd/cbeventlog
-# Couchbase proprietary end
 
 # TODO: golang17 version once available
 FROM node:16-alpine3.14 as ui-builder
@@ -45,6 +44,8 @@ FROM node:16-alpine3.14 as ui-builder
 COPY --from=builder /src/github.com/couchbaselabs/cbmultimanager/ui/ /src/github.com/couchbaselabs/cbmultimanager/ui/
 WORKDIR /src/github.com/couchbaselabs/cbmultimanager/ui
 RUN npm install && npm run build
+
+# Couchbase proprietary end
 
 # Combined image using Nginx as a base to support a simple web server plus proxying into endpoints
 FROM nginx:alpine

--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -34,8 +34,8 @@ RUN git rev-parse HEAD > /etc/couchbase/git-commit.txt
 
 # Statically build it to allow reuse on Alpine Linux
 RUN go mod download && \
-    CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbmultimanager ./cmd/cbmultimanager && \
-    CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbeventlog ./cmd/cbeventlog
+    CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbmultimanager ./cluster-monitor/cmd/cbmultimanager && \
+    CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbeventlog ./cluster-monitor/cmd/cbeventlog
 # Couchbase proprietary end
 
 # TODO: golang17 version once available
@@ -43,7 +43,7 @@ FROM node:16-alpine3.14 as ui-builder
 
 # Just copy over rather than clone
 COPY --from=builder /src/github.com/couchbaselabs/cbmultimanager/ui/ /src/github.com/couchbaselabs/cbmultimanager/ui/
-WORKDIR /src/github.com/couchbaselabs/cbmultimanager/ui/app/
+WORKDIR /src/github.com/couchbaselabs/cbmultimanager/ui
 RUN npm install && npm run build
 
 # Combined image using Nginx as a base to support a simple web server plus proxying into endpoints
@@ -234,7 +234,7 @@ COPY --from=builder /bin/cbmultimanager /bin/cbmultimanager
 COPY --from=builder /bin/cbeventlog /bin/cbeventlog
 COPY --from=builder /src/github.com/couchbaselabs/cbmultimanager/entrypoint.sh /entrypoints/couchbase-cluster-monitor.sh
 COPY --from=builder /etc/couchbase/git-commit.txt /etc/couchbase-cluster-monitor-release.txt
-COPY --from=ui-builder /src/github.com/couchbaselabs/cbmultimanager/ui/app/dist/app/ /ui/
+COPY --from=ui-builder /src/github.com/couchbaselabs/cbmultimanager/ui/dist/app/ /ui/
 
 RUN chmod a+x /bin/cbmultimanager /bin/cbeventlog
 
@@ -274,7 +274,11 @@ ENV PROMETHEUS_DYNAMIC_DIR=/etc/prometheus/couchbase/
 # Add all useful and required information
 COPY licenses/* /licenses/
 COPY README.md /help.1
-COPY git-commit.txt /etc/cmos-release.txt
+
+# TODO (CMOS-12): this doesn't work in the OSS build (and uses CBMM's version, not CMOS's)
+# Couchbase proprietary start
+COPY --from=builder /etc/couchbase/git-commit.txt /etc/cmos-release.txt
+# Couchbase proprietary end
 
 USER       $CB_UID
 ENTRYPOINT [ "/sbin/tini", "--", "/run.sh" ]


### PR DESCRIPTION
The path reorganisation in the cbmultimanager repo broke the microlith build. This PR fixes it. It also wraps creation of cmos-release.txt in a proprietary block, because that currently doesn't work in OSS.

Test Plan:
* Build the proprietary container (`docker build -t couchbase/cmos microlith`), verify it doesn't fail, verify running it (`docker run --rm -it couchbase/cmos:v1`) doesn't error
* Build the OSS container (`tools/build-oss-container.sh)`, verify it doesn't fail, verify running itverify running it (`docker run --rm -it couchbase/oss-cmos:v1`) doesn't error