### PR TITLE
CMOS-28: fix UI paths

### DIFF
--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -43,7 +43,8 @@ FROM node:16-alpine3.14 as ui-builder
 # Just copy over rather than clone
 COPY --from=builder /src/github.com/couchbaselabs/cbmultimanager/ui/ /src/github.com/couchbaselabs/cbmultimanager/ui/
 WORKDIR /src/github.com/couchbaselabs/cbmultimanager/ui
-RUN npm install && npm run build
+# We reverse proxy it to /couchbase/ so fix up the base and asset paths to account for this
+RUN npm install && npm run build -- --base-href=/couchbase/ui/ --deploy-url=/couchbase/ui/
 
 # Couchbase proprietary end
 

--- a/microlith/html/index.html
+++ b/microlith/html/index.html
@@ -18,7 +18,7 @@
     <li><a id="prometheus" href="prometheus/">Prometheus</a></li>
     <li><a id="jaeger" href="jaeger/">Jaeger</a></li>
     <li><a id="alertmanager" href="alertmanager/">Alert Manager</a></li>
-    <li><a id="couchbase" href="couchbase/">Couchbase Cluster Monitor</a></li>
+    <li><a id="couchbase" href="couchbase/ui/">Couchbase Cluster Monitor</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
As part of CMOS-16 we reorganised the build paths for the UI, which broke it in a reverse proxy context. This patch fixes those by building the UI to account for its `/couchbase/` prefix.

Test Plan:
* Build the CMOS image, run it with `-p 8080:8080`, verify you can access the static HTML page, click on the "Couchbase Cluster Monitor Link", and get the UI
* Build the OSS image as a sanity check (this only affects non-OSS parts)