### PR TITLE
Tweaked actions slightly to only build on PR or push to main

### DIFF
--- a/.github/workflows/pr-main-build.yml
+++ b/.github/workflows/pr-main-build.yml
@@ -1,32 +1,18 @@
 # Main workflow
-name: Build and test changes
+name: Build and test changes ready for PR signoff
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.adoc'
+    branches:
+      - main
   pull_request:
     branches:
       - main
 
 jobs:
-  cancel-identical-runs:
-    name: Cancel any other runs
-    runs-on: ubuntu-20.04
-    timeout-minutes: 5
-    steps:
-      # Prevent duplication on PRs and branch pushes
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   # TODO: split into push testing (smaller, just smoke) and PR testing (all of matrix)
   build-test-oss:
     name: CICD for the OSS variant
-    needs: cancel-identical-runs
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     strategy:
@@ -55,7 +41,6 @@ jobs:
 
   linting:
     name: Run static analysis and linting tools
-    needs: cancel-identical-runs
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Modified to try to prevent updates to PRs triggering duplicate builds.
Users should still be testing everything before a PR is triggered. We also want to verify on push to main as wel.