### PR TITLE
CMOS-100: Caching images across jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/cron-build.yml
+++ b/.github/workflows/cron-build.yml
@@ -7,17 +7,58 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-test-oss-containers-and-k8s:
-    name: Full build and test - OSS - containers and k8s
+  # Build an image to share across jobs
+  build-oss-container:
+    name: Build PR container for testing
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        server-version: [ '6.6.3' ] #, '7.0.1' ]
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build OSS container and export
+        run: |
+          make container-oss -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
+          docker save --output /tmp/cmos-image.tar docker.io/couchbaselabs:${{ github.sha }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: cmos-image
+          path: /tmp/cmos-image.tar
+
+  test-oss-containers-and-k8s:
+    name: Full build and test - OSS - containers and k8s
+    needs: build-oss-container
+    runs-on: ubuntu-20.04
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        server-version: [ '6.6.3', '7.0.2' ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: cmos-image
+          path: /tmp
+
+      - name: Load CMOS image
+        run: |
+          docker load --input /tmp/cmos-image.tar
+          docker image ls -a
 
       - name: Install BATS
         timeout-minutes: 5
@@ -30,34 +71,48 @@ jobs:
         with:
           cluster_name: kind-${{ github.sha }}
 
-      # TODO: cache single container build across matrix runs
       - name: Run ${{ matrix.server-version }} tests
         run: |
-          make TEST_SUITE=all container-oss test-containers -e COUCHBASE_SERVER_IMAGE=couchbase/server:${{ matrix.server-version }} -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
+          make TEST_SUITE=all test-containers -e COUCHBASE_SERVER_IMAGE=couchbase/server:${{ matrix.server-version }} -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
           # CMOS-97
           make TEST_SUITE=integration/kubernetes test-kubernetes -e COUCHBASE_SERVER_IMAGE=couchbase/server:${{ matrix.server-version }} -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
-  
+
   build-test-oss-native:
     name: CICD for the OSS variant (Native)
     runs-on: macos-10.15 # Apparently macOS is the only environment that supports nested virtualisation
-    timeout-minutes: 60
+    needs: build-oss-container
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        server-version: [ '6.6.3' ] #, '7.0.1' ]
+        server-version: [ '6.6.3', '7.0.2' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      
+
       - name: Setup Docker
         uses: docker-practice/actions-setup-docker@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: cmos-image
+          path: /tmp
+
+      - name: Load CMOS image
+        run: |
+          docker load --input /tmp/cmos-image.tar
+          docker image ls -a
 
       - name: Install requirements
         timeout-minutes: 15
         run: |
           brew unlink bats # The version that ships with the image is outdated
           brew install bats-core ansible
- 
+
       - name: Run ${{ matrix.server-version }} tests
         run: |
-          make TEST_SUITE=all container-oss test-native -e COUCHBASE_SERVER_IMAGE=couchbase/server:${{ matrix.server-version }} -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
+          make TEST_SUITE=all test-native -e COUCHBASE_SERVER_IMAGE=couchbase/server:${{ matrix.server-version }} -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}

--- a/.github/workflows/pr-main-build.yml
+++ b/.github/workflows/pr-main-build.yml
@@ -8,29 +8,69 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
-  build-test-oss-containers:
+
+  # Build an image to share across jobs
+  build-oss-container:
+    name: Build PR container for testing
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build OSS container and export
+        run: |
+          make container-oss -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
+          docker save --output /tmp/cmos-image.tar docker.io/couchbaselabs:${{ github.sha }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: cmos-image
+          path: /tmp/cmos-image.tar
+
+  smoke-test-oss-containers:
     name: Smoke tests - OSS - containers
+    needs: build-oss-container
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        server-version: [ '6.6.3' ] #, '7.0.1' ]
+        server-version: [ '6.6.3', '7.0.2' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: cmos-image
+          path: /tmp
+
+      - name: Load CMOS image
+        run: |
+          docker load --input /tmp/cmos-image.tar
+          docker image ls -a
 
       - name: Install BATS
         timeout-minutes: 5
         run: |
           sudo npm install -g bats
 
-      # TODO: cache single container build across matrix runs
       - name: Run ${{ matrix.server-version }} tests
         run: |
-          make TEST_SUITE=smoke container-oss test-containers -e COUCHBASE_SERVER_IMAGE=couchbase/server:${{ matrix.server-version }} -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
+          make TEST_SUITE=smoke test-containers -e COUCHBASE_SERVER_IMAGE=couchbase/server:${{ matrix.server-version }} -e DOCKER_USER=docker.io/couchbaselabs -e DOCKER_TAG=${{ github.sha }}
 
   # TODO: once CMOS-97 is done, add something similar for k8s
 
@@ -45,5 +85,6 @@ jobs:
       - name: Run linting
         run: |
           sudo apt install aspell
+          pip3 install "ansible-lint[community,yamllint]"
           make lint
 

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -4,9 +4,6 @@ name: trivy security analysis
 on:
   push:
     branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '44 13 * * 4'
 


### PR DESCRIPTION
Tweaks to handle only building once per workflow and sharing the container across jobs.
Updated to also run 7.0.2 tests.