### PR TITLE
Allow customising the ref to use for manual full CI runs

### DIFF
--- a/.github/workflows/cron-build.yml
+++ b/.github/workflows/cron-build.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v2
               with:
-                ref: ${{ github.event.inputs.ref }} # Default is an empty string, which means main branch
+                ref: ${{ github.event.inputs.ref || 'main' }}
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
@@ -51,7 +51,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v2
               with:
-                ref: ${{ github.event.inputs.ref }} # Default is an empty string, which means main branch
+                ref: ${{ github.event.inputs.ref || 'main' }}
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
@@ -97,7 +97,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v2
               with:
-                ref: ${{ github.event.inputs.ref }} # Default is an empty string, which means main branch
+                ref: ${{ github.event.inputs.ref || 'main' }}
 
             - name: Setup Docker
               uses: docker-practice/actions-setup-docker@master


### PR DESCRIPTION
Note that I haven't tested this - this might get tripped up on `github.event.inputs` being undefined on a cron run