### PR TITLE
config-svc: disable cgo for microlith build

### DIFF
--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -Lo /src/prom.tgz "https://github.com/lablabs/prometheus-alert-override
 WORKDIR /src/github.com/couchbaselabs/observability/config-svc
 COPY config-svc/ .
 RUN go mod download && \
-    CGO_ENABLED=0 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cmoscfg -tags netgo ./cmd/cmoscfg
+    CGO_ENABLED=0 GOOS=linux go build -trimpath -a -o /bin/cmoscfg -tags netgo ./cmd/cmoscfg
 
 # Couchbase proprietary start
 # Standalone as need to use --mount option


### PR DESCRIPTION
For consistency, we would use cgo to build config-svc, but that makes portability difficult since it has to link against various system libraries, plus it can cause build issues. We don't actually need it though (unlike e.g. cbmultimanager which uses sqlite)

Disable cgo and set the `netgo` build tag to use a pure-go version of the net package.

Tested a `make container`.