### PR TITLE
CMOS-115 Install Grafana plugins at runtime

### DIFF
--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -237,6 +237,16 @@ COPY grafana/cblogo.png /usr/share/grafana/public/img/cblogo.png
 ENV GF_SECURITY_ADMIN_PASSWORD=password
 ENV GF_USERS_ALLOW_SIGN_UP=false
 
+# Ensure we install Grafana plugins at build time, not at runtime
+ARG GF_INSTALL_PLUGINS=marcusolsson-json-datasource=1.3.0
+COPY ./scripts/install-grafana-plugins.sh /scripts/install-grafana-plugins.sh
+RUN chmod +x /scripts/install-grafana-plugins.sh && \
+    /scripts/install-grafana-plugins.sh \
+# Blank out the environment variable to prevent trying to install the plugins again at runtime
+# End-users can still override it to install additional plugins, but this should prevent startup
+# failures in an air-gapped environment
+ENV GF_INSTALL_PLUGINS=""
+
 COPY prometheus/ /etc/prometheus/
 COPY alertmanager/ /etc/alertmanager/
 COPY jaeger/ /etc/jaeger/

--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -238,10 +238,12 @@ ENV GF_SECURITY_ADMIN_PASSWORD=password
 ENV GF_USERS_ALLOW_SIGN_UP=false
 
 # Ensure we install Grafana plugins at build time, not at runtime
+# We use a slightly different syntax of GF_INSTALL_PLUGINS to allow pinning versions:
+# should be a comma-separated list of plugins, optionally with a =<version> to download that version.
+# If no version is given, use the latest.
 ARG GF_INSTALL_PLUGINS=marcusolsson-json-datasource=1.3.0
 COPY ./scripts/install-grafana-plugins.sh /scripts/install-grafana-plugins.sh
-RUN chmod +x /scripts/install-grafana-plugins.sh && \
-    /scripts/install-grafana-plugins.sh \
+RUN /bin/bash /scripts/install-grafana-plugins.sh \
 # Blank out the environment variable to prevent trying to install the plugins again at runtime
 # End-users can still override it to install additional plugins, but this should prevent startup
 # failures in an air-gapped environment

--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -239,9 +239,9 @@ ENV GF_USERS_ALLOW_SIGN_UP=false
 
 # Ensure we install Grafana plugins at build time, not at runtime
 # We use a slightly different syntax of GF_INSTALL_PLUGINS to allow pinning versions:
-# should be a comma-separated list of plugins, optionally with a =<version> to download that version.
+# should be a comma-separated list of plugins, optionally with a space and a version to download that version.
 # If no version is given, use the latest.
-ARG GF_INSTALL_PLUGINS=marcusolsson-json-datasource=1.3.0
+ARG GF_INSTALL_PLUGINS="marcusolsson-json-datasource 1.3.0"
 COPY ./scripts/install-grafana-plugins.sh /scripts/install-grafana-plugins.sh
 RUN /bin/bash /scripts/install-grafana-plugins.sh \
 # Blank out the environment variable to prevent trying to install the plugins again at runtime

--- a/microlith/run.sh
+++ b/microlith/run.sh
@@ -35,9 +35,6 @@ export ALERTMANAGER_URL_SUBPATH=${ALERTMANAGER_URL_SUBPATH-/alertmanager/}
 
 export LOKI_CONFIG_FILE=${LOKI_CONFIG_FILE:-/etc/loki/local-config.yaml}
 
-# TODO (CMOS-115): this should be done at build time
-export GF_INSTALL_PLUGINS=${GF_INSTALL_PLUGINS:-marcusolsson-json-datasource}
-
 export JAEGER_URL_SUBPATH=${JAEGER_URL_SUBPATH-/jaeger}
 export JAEGER_CONFIG_FILE=${JAEGER_CONFIG_FILE:-/etc/jaeger/config.json}
 export SPAN_STORAGE_TYPE=${SPAN_STORAGE_TYPE:-memory}

--- a/microlith/scripts/install-grafana-plugins.sh
+++ b/microlith/scripts/install-grafana-plugins.sh
@@ -15,14 +15,20 @@ set -euo pipefail
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Install the Grafana plugins given in GF_INSTALL_PLUGINS.
+# Follows the exact same format as expected by the official Grafana Docker image - a comma-separated list of plugins,
+# optionally with the version, space-separated. For example, `marcusolsson-json-datasource 1.3.0,other-test-plugin`.
+# Note that the ZIP URL syntax is currently not supported, so only plugins from grafana.com can be installed.
+# Upstream docs: https://grafana.com/docs/grafana/latest/installation/docker/#install-official-and-community-grafana-plugins
+
 if [ -n "$GF_INSTALL_PLUGINS" ]; then
   old_ifs=$IFS
   IFS=','
   tmp_dir=$(mktemp -d)
   for plugin_arg in ${GF_INSTALL_PLUGINS}; do
     IFS=$old_ifs
-    # Can be just the bare name (for the latest version) or name=version
-    if [[ "$plugin_arg" =~ ^(.*)=(.*)$ ]]; then
+    # Can be just the bare name (for the latest version) or `name version`
+    if [[ "$plugin_arg" =~ ^(.*)[[:space:]](.*)$ ]]; then
       plugin_name="${BASH_REMATCH[1]}"
       plugin_version="${BASH_REMATCH[2]}"
     else

--- a/microlith/scripts/install-grafana-plugins.sh
+++ b/microlith/scripts/install-grafana-plugins.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -n "$GF_INSTALL_PLUGINS" ]; then
+  old_ifs=$IFS
+  IFS=','
+  tmp_dir=$(mktemp -d)
+  for plugin_arg in ${GF_INSTALL_PLUGINS}; do
+    IFS=$old_ifs
+    # Can be just the bare name (for the latest version) or name=version
+    if [[ "$plugin_arg" =~ ^(.*)=(.*)$ ]]; then
+      plugin_name="${BASH_REMATCH[1]}"
+      plugin_version="${BASH_REMATCH[2]}"
+    else
+      plugin_name=$plugin_arg
+      plugin_version=latest
+    fi
+    wget -O "$tmp_dir/$plugin_name.zip" "https://grafana.com/api/plugins/$plugin_name/versions/$plugin_version/download"
+    unzip -d "$GF_PATHS_PLUGINS" "$tmp_dir/$plugin_name.zip"
+    rm "$tmp_dir/$plugin_name.zip"
+  done
+fi

--- a/testing/bats/smoke/grafana-plugins.bats
+++ b/testing/bats/smoke/grafana-plugins.bats
@@ -22,11 +22,12 @@ ensure_variables_set CMOS_HOST BATS_SUPPORT_ROOT BATS_ASSERT_ROOT
 load "$BATS_SUPPORT_ROOT/load.bash"
 load "$BATS_ASSERT_ROOT/load.bash"
 
-# The list of plugins will vary, so we only test if at least one is present
 @test "community Grafana plugins present" {
     wait_for_url 10 "$CMOS_HOST/grafana/api/health"
     run curl -fs -o "$BATS_TEST_TMPDIR/output.json" "$CMOS_HOST/grafana/api/plugins"
     assert_success
     run jq -c '.[] | select(.signatureType == "community")' "$BATS_TEST_TMPDIR/output.json"
     [ -n "$output" ]
+    # Add any specific plugins we user here
+    assert_line -p 'marcusolsson-json-datasource'
 }

--- a/testing/bats/smoke/grafana-plugins.bats
+++ b/testing/bats/smoke/grafana-plugins.bats
@@ -28,6 +28,6 @@ load "$BATS_ASSERT_ROOT/load.bash"
     assert_success
     run jq -c '.[] | select(.signatureType == "community")' "$BATS_TEST_TMPDIR/output.json"
     [ -n "$output" ]
-    # Add any specific plugins we user here
+    # Add any specific plugins we use here
     assert_line -p 'marcusolsson-json-datasource'
 }

--- a/testing/bats/smoke/grafana-plugins.bats
+++ b/testing/bats/smoke/grafana-plugins.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load "$HELPERS_ROOT/test-helpers.bash"
+load "$HELPERS_ROOT/url-helpers.bash"
+
+ensure_variables_set CMOS_HOST BATS_SUPPORT_ROOT BATS_ASSERT_ROOT
+
+load "$BATS_SUPPORT_ROOT/load.bash"
+load "$BATS_ASSERT_ROOT/load.bash"
+
+# The list of plugins will vary, so we only test if at least one is present
+@test "community Grafana plugins present" {
+    wait_for_url 10 "$CMOS_HOST/grafana/api/health"
+    run curl -fs -o "$BATS_TEST_TMPDIR/output.json" "$CMOS_HOST/grafana/api/plugins"
+    assert_success
+    run jq -c '.[] | select(.signatureType == "community")' "$BATS_TEST_TMPDIR/output.json"
+    [ -n "$output" ]
+}


### PR DESCRIPTION
Ensure we install the Grafana plugins we need at runtime, and lock them to a specific version - means the image becomes more portable, and also usable in an air-gapped deployment.

Testing:
* Built an image, ensured it runs and the plugin we need is usable
* Added smoke test to cover plugin installation
* make TEST_SUITE=smoke test-containers