### PR TITLE
Smoke: initialise CB clusters, add Prometheus exporter, and test it all works

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ You can run each platform's tests by running `make test-native`, `make test-cont
 
 To run each platform's tests, you will need:
 
-* Native: [Vagrant](http://vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/)
+* Native: [Vagrant](http://vagrantup.com/), [VirtualBox](https://www.virtualbox.org/), and [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 * Containers: a Docker daemon (on Windows or macOS you can use Docker Desktop)
 * Kubernetes: same as above, plus either a running Kubernetes cluster or [kind](https://kind.sigs.k8s.io/)
   * If you use the latter, set the environment variable `SKIP_CLUSTER_CREATION=no` and the tests will take care of starting up an isolated cluster.

--- a/testing/bats/smoke/couchbase-exporter.bats
+++ b/testing/bats/smoke/couchbase-exporter.bats
@@ -20,39 +20,63 @@ load "$HELPERS_ROOT/url-helpers.bash"
 load "$BATS_SUPPORT_ROOT/load.bash"
 load "$BATS_ASSERT_ROOT/load.bash"
 
+# Helper function to wrap querying Prometheus and processing the result.
+# Parameters:
+# $1: the number of nodes we expect to see
+# Returns:
+# 0 if we get the expected number of nodes
+# 1 if we got a result, but it didn't have the expected number of nodes
+# 2 if we got nothing at all, or something else went wrong
 function try_query() {
+  local expected_nodes=$1
   run curl -o "$BATS_TEST_TMPDIR/output.json" -X GET "$CMOS_HOST/prometheus/api/v1/query?query=cbnode_up==1"
   if [ "$status" -ne 0 ]; then
-    return 1
+    return 2
   fi
 
   run jq -c '.data.result[]' "$BATS_TEST_TMPDIR/output.json"
   if [ "$status" -ne 0 ]; then
-    return 1
+    return 2
   fi
 
-  if [ "${#lines[@]}" -gt 0 ]; then
+  if [ "${#lines[@]}" -eq "$expected_nodes" ]; then
     return 0
-  else
+  elif [ "${#lines[@]}" -gt 0 ]; then
     return 1
+  else
+    return 2
   fi
 }
 
 @test "Couchbase Exporter is scraped" {
   wait_for_url 10 "$CMOS_HOST/prometheus/-/ready"
 
-  attempt=0
-  max_attempts=10
+  local attempt=0
+  local max_attempts=10
+  local failure_reason_code
   while [ "$attempt" -lt "$max_attempts" ]; do
-    if try_query; then
+    if try_query "$COUCHBASE_SERVER_NODES"; then
       break
     else
+      failure_reason_code=$?
       attempt=$(( attempt + 1 ))
       sleep 5
       continue
     fi
   done
   if [ "$attempt" -eq "$max_attempts" ]; then
-    fail "Failed to query cbnode_up after $attempt attempts. Last query result: $(cat "$BATS_TEST_TMPDIR/output.json")"
+    local failure_message
+    case $failure_reason_code in
+      1)
+        failure_message="cbnode_up did not have the expected number of results after $attempt attempts."
+        ;;
+      2)
+        failure_message="Failed to query cbnode_up after $attempt attempts."
+        ;;
+      *)
+        failure_message="try_query returned $failure_reason_code after $attempt attempts."
+        ;;
+    esac
+    fail "$failure_message Last query result: $(cat "$BATS_TEST_TMPDIR/output.json")"
   fi
 }

--- a/testing/bats/smoke/couchbase-exporter.bats
+++ b/testing/bats/smoke/couchbase-exporter.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load "$HELPERS_ROOT/test-helpers.bash"
+load "$HELPERS_ROOT/url-helpers.bash"
+
+load "$BATS_SUPPORT_ROOT/load.bash"
+load "$BATS_ASSERT_ROOT/load.bash"
+
+function try_query() {
+  run curl -o "$BATS_TEST_TMPDIR/output.json" -X GET "$CMOS_HOST/prometheus/api/v1/query?query=cbnode_up==1"
+  if [ "$status" -ne 0 ]; then
+    return 1
+  fi
+
+  run jq -c '.data.result[]' "$BATS_TEST_TMPDIR/output.json"
+  if [ "$status" -ne 0 ]; then
+    return 1
+  fi
+
+  if [ "${#lines[@]}" -gt 0 ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+@test "Couchbase Exporter is scraped" {
+  wait_for_url 10 "$CMOS_HOST/prometheus/-/ready"
+
+  attempt=0
+  max_attempts=10
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    if try_query; then
+      break
+    else
+      attempt=$(( attempt + 1 ))
+      sleep 5
+      continue
+    fi
+  done
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    fail "Failed to query cbnode_up after $attempt attempts. Last query result: $(cat "$BATS_TEST_TMPDIR/output.json")"
+  fi
+}

--- a/testing/helpers/couchbase-helpers.bash
+++ b/testing/helpers/couchbase-helpers.bash
@@ -22,3 +22,28 @@ function get_service_port() {
     ports=$(docker ps --filter "name=$1" --format "{{.Ports}}")
     echo "${ports}" | sed -e 's/, /\n/g' | perl -ne 'print "$1" if /0.0.0.0:(\d+)->'"$2"'/'
 }
+
+# Initializes a Couchbase Server cluster.
+# Uses the list of nodes in $COUCHBASE_SERVER_HOSTS. Passes through the arguments in $1 to `docker run`.
+# Exits immediately if it encounters an error.
+# Arguments:
+# $1: the path to couchbase-cli, or a command that runs it (e.g. `docker run couchbase couchbase-cli`)
+function initialize_couchbase_cluster() {
+  set -euo pipefail
+  # cluster-init the first node
+  first_node=$(echo "$COUCHBASE_SERVER_HOSTS" | head -n1)
+  # shellcheck disable=SC2086
+  $1 cluster-init \
+    --cluster "$first_node" --cluster-username Administrator \
+    --cluster-password password --cluster-ramsize 256 --cluster-fts-ramsize 256 --cluster-index-ramsize 256 \
+    --cluster-eventing-ramsize 256 --cluster-analytics-ramsize 1024 --cluster-name "CMOS Smoke Cluster" \
+    --services data,index,query --update-notifications 0
+
+  # Add the remaining nodes to it
+  # shellcheck disable=SC2086
+  $1 server-add \
+        --cluster "$first_node" --username Administrator --password password \
+        --server-add "$(echo "$COUCHBASE_SERVER_HOSTS" | tail -n +2 | sed -e 's/:8091/:18091/g' | paste -sd ',' -)" \
+        --server-add-username Administrator --server-add-password password \
+        --services data,index,query
+}

--- a/testing/helpers/native-helpers.bash
+++ b/testing/helpers/native-helpers.bash
@@ -77,6 +77,6 @@ function teardown_vagrant_cluster() {
     local cb_version=${1:-6.6.3}
     local os=${2:-centos7}
     pushd "$RESOURCES_ROOT/native/vagrants/$cb_version/$os" || return
-        vagrant halt --no-tty
+        vagrant destroy --no-tty -f
     popd || return
 }

--- a/testing/helpers/test-helpers.bash
+++ b/testing/helpers/test-helpers.bash
@@ -111,7 +111,7 @@ function start_smoke_cluster() {
             ensure_variables_set CMOS_IMAGE
             ensure_variables_set COUCHBASE_SERVER_IMAGE
             # Build a new image, containing the Exporter
-            docker build -t "$COUCHBASE_SERVER_IMAGE-exporter" \
+            DOCKER_BUILDKIT=1 docker build -t "$COUCHBASE_SERVER_IMAGE-exporter" \
              --build-arg COUCHBASE_SERVER_IMAGE="$COUCHBASE_SERVER_IMAGE" \
               -f "$RESOURCES_ROOT/containers/cb-with-exporter.Dockerfile" "$RESOURCES_ROOT/containers"
             export COUCHBASE_SERVER_IMAGE="$COUCHBASE_SERVER_IMAGE-exporter"

--- a/testing/helpers/test-helpers.bash
+++ b/testing/helpers/test-helpers.bash
@@ -90,6 +90,7 @@ function _start_cmos() {
 # This function will set the following variables with its results:
 # $COUCHBASE_SERVER_HOSTS: the hostname/IP and management port of every CBS node, separated by newlines
 #   (Note that they may not be accessible from localhost, e.g. if running in a container - they'll be accessible to CMOS though)
+# $COUCHBASE_SERVER_NODES: the number of nodes running
 # $CMOS_HOST: the hostname/IP and nginx port of the running CMOS container
 #
 # Note: do not call this function using BATS run! Otherwise its variables will not be set.
@@ -99,6 +100,7 @@ function start_smoke_cluster() {
     case $TEST_PLATFORM in
         native)
             export VAGRANT_NODES=$nodes
+            export COUCHBASE_SERVER_NODES=$nodes
             start_vagrant_cluster "$COUCHBASE_SERVER_VERSION" "centos7"
             while IFS= read -r host; do
               wait_for_url 10 "$host/ui"
@@ -128,6 +130,7 @@ function start_smoke_cluster() {
             done
             COUCHBASE_SERVER_HOSTS=$(seq -f "couchbase%g.local" 1 "$nodes")
             export COUCHBASE_SERVER_HOSTS
+            export COUCHBASE_SERVER_NODES=$nodes
             # Can't just use COUCHBASE_SERVER_HOSTS as they won't be accessible outside the container network
             local mgmt_port
             mgmt_port=$(docker inspect test_couchbase1 -f '{{with index .NetworkSettings.Ports "8091/tcp"}}{{ with index . 0 }}{{ .HostPort }}{{end}}{{end}}')

--- a/testing/resources/containers/cb-with-exporter.Dockerfile
+++ b/testing/resources/containers/cb-with-exporter.Dockerfile
@@ -1,0 +1,18 @@
+# Change
+ARG couchbase_server_image=couchbase/server:enterprise-6.6.3
+
+# Build the exporter
+FROM golang:1.17.2 as go_build
+RUN git clone https://github.com/couchbase/couchbase-exporter.git /opt/couchbase-exporter
+
+WORKDIR /opt/couchbase-exporter
+RUN CGO_ENABLED=0 go build -o ./couchbase-exporter .
+
+# Add to Couchbase Server
+# hadolint ignore=DL3006
+FROM $couchbase_server_image
+
+COPY --chown=couchbase:couchbase --chmod=777 ./run_exporter.sh /etc/service/couchbase-exporter/run
+COPY --from=go_build --chmod=775 /opt/couchbase-exporter/couchbase-exporter /opt/couchbase-exporter
+RUN chown couchbase:couchbase /opt/couchbase-exporter
+EXPOSE 9091

--- a/testing/resources/containers/cb-with-exporter.Dockerfile
+++ b/testing/resources/containers/cb-with-exporter.Dockerfile
@@ -1,13 +1,13 @@
 ARG couchbase_server_image=couchbase/server:enterprise-6.6.3
-ARG exporter_version=master
 
 # Build the exporter
 FROM golang:1.17.2 as go_build
 RUN git clone https://github.com/couchbase/couchbase-exporter.git /opt/couchbase-exporter
 
 WORKDIR /opt/couchbase-exporter
-RUN git checkout $exporter_version
-RUN CGO_ENABLED=0 go build -o ./couchbase-exporter .
+ARG exporter_version=master
+RUN git checkout "$exporter_version" &&\
+    CGO_ENABLED=0 go build -o ./couchbase-exporter .
 
 # Add to Couchbase Server
 # hadolint ignore=DL3006

--- a/testing/resources/containers/cb-with-exporter.Dockerfile
+++ b/testing/resources/containers/cb-with-exporter.Dockerfile
@@ -1,18 +1,19 @@
-# Change
 ARG couchbase_server_image=couchbase/server:enterprise-6.6.3
+ARG exporter_version=master
 
 # Build the exporter
 FROM golang:1.17.2 as go_build
 RUN git clone https://github.com/couchbase/couchbase-exporter.git /opt/couchbase-exporter
 
 WORKDIR /opt/couchbase-exporter
+RUN git checkout $exporter_version
 RUN CGO_ENABLED=0 go build -o ./couchbase-exporter .
 
 # Add to Couchbase Server
 # hadolint ignore=DL3006
 FROM $couchbase_server_image
+EXPOSE 9091
 
 COPY --chown=couchbase:couchbase --chmod=777 ./run_exporter.sh /etc/service/couchbase-exporter/run
 COPY --from=go_build --chmod=775 /opt/couchbase-exporter/couchbase-exporter /opt/couchbase-exporter
 RUN chown couchbase:couchbase /opt/couchbase-exporter
-EXPOSE 9091

--- a/testing/resources/containers/run_exporter.sh
+++ b/testing/resources/containers/run_exporter.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start the couchbase-exporter. Couchbase Server may or may not be running already
+exec /opt/couchbase-exporter

--- a/testing/resources/containers/run_exporter.sh
+++ b/testing/resources/containers/run_exporter.sh
@@ -14,5 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Start the couchbase-exporter. Couchbase Server may or may not be running already
+# Start the couchbase-exporter.
+# Both this and CBS will be started by runsvdir-start concurrently, so it is possible that
+# the exporter starts before CBS starts. As of https://github.com/couchbase/couchbase-exporter/commit/61914d56c15580b59910cca97eaedaed4aafbcff
+# this should be safe.
 exec /opt/couchbase-exporter


### PR DESCRIPTION
This PR improves the smoke suite by:

* Initialising the Couchbase Server cluster
* Adding the Prometheus Exporter to the CB nodes in Containers tests, and
* Testing that both of the above worked, by querying `cbnode_up==1`
