### PR TITLE
CMOS-74: Rename Inventory Dashboard

### DIFF
--- a/microlith/grafana/grafana.ini
+++ b/microlith/grafana/grafana.ini
@@ -7,7 +7,7 @@ serve_from_sub_path = true
 versions_to_keep = 1
 
 # Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
-default_home_dashboard_path = /etc/grafana/provisioning/dashboards/cluster-overview.json
+default_home_dashboard_path = /etc/grafana/provisioning/dashboards/couchbase-inventory.json
 
 [auth.anonymous]
 # enable anonymous access

--- a/microlith/grafana/provisioning/dashboards/cluster-overview.json
+++ b/microlith/grafana/provisioning/dashboards/cluster-overview.json
@@ -22,12 +22,12 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 4,
   "links": [],
   "panels": [
     {
       "datasource": "JSON API",
-      "description": "A description for the Cluster Overview.",
+      "description": "A summary view of all Couchbase Clusters within the estate.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -68,7 +68,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Status: Good"
+              "options": "Successful"
             },
             "properties": [
               {
@@ -87,7 +87,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Status: Warning"
+              "options": "Warnings"
             },
             "properties": [
               {
@@ -105,7 +105,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Status: Alert"
+              "options": "Critical"
             },
             "properties": [
               {
@@ -147,7 +147,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Status: Info"
+              "options": "Info Alerts"
             },
             "properties": [
               {
@@ -208,19 +208,28 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Host"
+              "options": "Cluster"
             },
             "properties": [
               {
                 "id": "custom.width",
                 "value": 185
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Go to Couchbase UI",
+                    "url": "${__data.fields.Cluster}"
+                  }
+                ]
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "Links"
+              "options": "Name"
             },
             "properties": [
               {
@@ -255,7 +264,7 @@
           "fields": [
             {
               "jsonPath": "$[*].nodes_summary[0].host",
-              "name": "Host"
+              "name": "Cluster"
             },
             {
               "jsonPath": "$[*].name",
@@ -278,29 +287,29 @@
               "name": "Services"
             },
             {
-              "jsonPath": "$[*].status_summary.good",
+              "jsonPath": "$[*].status_summary.alerts",
               "language": "jsonpath",
-              "name": "Status: Good"
+              "name": "Critical"
             },
             {
               "jsonPath": "$[*].status_summary.warnings",
               "language": "jsonpath",
-              "name": "Status: Warning"
+              "name": "Warnings"
             },
             {
-              "jsonPath": "$[*].status_summary.alerts",
+              "jsonPath": "$[*].status_summary.good",
               "language": "jsonpath",
-              "name": "Status: Alert"
+              "name": "Successful"
             },
             {
               "jsonPath": "$[*].status_summary.info",
               "language": "jsonpath",
-              "name": "Status: Info"
+              "name": "Info Alerts"
             },
             {
               "jsonPath": "$map($, function($_) {\"Cluster Overview\"})",
               "language": "jsonata",
-              "name": "Links"
+              "name": "Dashboard"
             }
           ],
           "method": "GET",
@@ -309,7 +318,27 @@
           "urlPath": "/clusters"
         }
       ],
-      "title": "Cluster overview",
+      "title": "Inventory of Couchbase Clusters",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Name",
+                "Version",
+                "Nodes",
+                "Services",
+                "Critical",
+                "Warnings",
+                "Successful",
+                "Info Alerts",
+                "Cluster"
+              ]
+            }
+          }
+        }
+      ],
       "type": "table"
     }
   ],
@@ -327,6 +356,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Cluster Overview Dashboard",
-  "uid": null,
-  "version": 1
+  "uid": "ldfS-1F7z",
+  "version": 7
 }

--- a/microlith/grafana/provisioning/dashboards/couchbase-inventory.json
+++ b/microlith/grafana/provisioning/dashboards/couchbase-inventory.json
@@ -18,11 +18,11 @@
       }
     ]
   },
-  "description": "Overview of all clusters known to this instance",
+  "description": "Overview of all Couchbase clusters known to this instance",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -219,6 +219,7 @@
                 "id": "links",
                 "value": [
                   {
+                    "targetBlank": true,
                     "title": "Go to Couchbase UI",
                     "url": "${__data.fields.Cluster}"
                   }
@@ -305,11 +306,6 @@
               "jsonPath": "$[*].status_summary.info",
               "language": "jsonpath",
               "name": "Info Alerts"
-            },
-            {
-              "jsonPath": "$map($, function($_) {\"Cluster Overview\"})",
-              "language": "jsonata",
-              "name": "Dashboard"
             }
           ],
           "method": "GET",
@@ -319,26 +315,7 @@
         }
       ],
       "title": "Inventory of Couchbase Clusters",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Name",
-                "Version",
-                "Nodes",
-                "Services",
-                "Critical",
-                "Warnings",
-                "Successful",
-                "Info Alerts",
-                "Cluster"
-              ]
-            }
-          }
-        }
-      ],
+      "transformations": [],
       "type": "table"
     }
   ],
@@ -355,7 +332,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Cluster Overview Dashboard",
+  "title": "Couchbase Inventory",
   "uid": "ldfS-1F7z",
-  "version": 7
+  "version": 3
 }


### PR DESCRIPTION
* Renamed "Cluster Overview" dashboard to "Couchbase Inventory"
* Reordered the table headings so the important stuff appears first
* Renamed the table headings
* Added links to the Cluster UI and made the cluster name link to the individual dashboard.