### PR TITLE
CMOS-77: Use couchbase_exporter role in native tests

### DIFF
--- a/testing/helpers/native-helpers.bash
+++ b/testing/helpers/native-helpers.bash
@@ -42,7 +42,7 @@ function start_vagrant_cluster() {
         git clone --depth=1 https://github.com/couchbaselabs/vagrants.git "$RESOURCES_ROOT/native/vagrants"
     fi
 
-    ansible-galaxy install -r "$RESOURCES_ROOT/native/requirements.yml"
+    ansible-galaxy install --force -r "$RESOURCES_ROOT/native/requirements.yml"
 
     temporary_dir=$(mktemp -d)
 

--- a/testing/resources/native/playbook.yml
+++ b/testing/resources/native/playbook.yml
@@ -1,64 +1,14 @@
 ---
 - hosts: couchbase
-  vars:
-      go_version: 1.17.2
-  environment:
-      GOROOT: /usr/local/go
-      PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin'
-  tasks:
-      - name: Install required packages
-        package:
-            name:
-                - git
-                - wget
-                # Needed to avoid Git using TLS 1.1 which GitHub rejects
-                - nss
-                - curl
-                - libcurl
-                - python2 # TODO: ideally we'd be using 3
-            state: latest
-        become: true
-      - name: Download Golang
-        get_url:
-            url: https://golang.org/dl/go{{ go_version }}.linux-amd64.tar.gz
-            dest: /tmp/golang.tar.gz
-      - name: Install Golang
-        unarchive:
-            src: /tmp/golang.tar.gz
-            remote_src: true
-            dest: /usr/local/
-        become: true
-      - name: Create directory for couchbase-exporter
-        file:
-            path: /opt/couchbase-exporter
-            state: directory
-            owner: vagrant
-            group: vagrant
-            mode: 0777
-        become: true
-      - name: Download couchbase-exporter sources
-        git:
-            repo: https://github.com/couchbase/couchbase-exporter.git
-            dest: /opt/couchbase-exporter
-      - name: Build couchbase-exporter
-        command:
-            cmd: go build -o ./couchbase-exporter .
-            chdir: /opt/couchbase-exporter
-            creates: /opt/couchbase-exporter/couchbase-exporter
-      - name: Set up couchbase-exporter systemd service
-        template:
-            src: couchbase-exporter.service.j2
-            dest: /etc/systemd/system/couchbase-exporter.service
-            owner: root
-            group: root
-            mode: 0644
-        become: true
-      - name: Start couchbase-exporter
-        systemd:
-            name: couchbase-exporter.service
-            state: started
-            daemon_reload: true
-        become: true
-      - name: Wait for couchbase-exporter to start
-        wait_for:
-            port: 9091
+  pre_tasks:
+  - name: Install required packages
+    package:
+        name:
+            - python3
+        state: latest
+    become: true
+  roles:
+    - role: couchbaselabs.couchbase_exporter
+      vars:
+        # TODO: once https://issues.couchbase.com/browse/PE-56 is done, replace this with a tagged version
+        couchbase_exporter_verison: 61914d56c15580b59910cca97eaedaed4aafbcff

--- a/testing/resources/native/requirements.yml
+++ b/testing/resources/native/requirements.yml
@@ -1,1 +1,5 @@
---- []
+---
+- name: couchbaselabs.couchbase_exporter
+  src: https://github.com/couchbaselabs/ansible-couchbase-exporter.git
+  # TODO: replace with main (or a tagged version) once https://github.com/couchbaselabs/ansible-couchbase-exporter/pull/3 is merged
+  version: download-directory


### PR DESCRIPTION
Switch native tests from using our own hand-crafted Ansible playbook to install the Exporter to using https://github.com/couchbaselabs/ansible-couchbase-exporter.

Do not merge before https://github.com/couchbaselabs/ansible-couchbase-exporter/pull/3 is merged into main.