### PR TITLE
CMOS-131: Avoid clobbering `cluster` label when adding a cluster

### DIFF
--- a/config-svc/pkg/api/routes_v1.go
+++ b/config-svc/pkg/api/routes_v1.go
@@ -45,6 +45,9 @@ func (s *Server) PostAddPrometheusTarget(ctx echo.Context) error {
 	}
 
 	labels := data.Labels.AdditionalProperties
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 	if data.NameLabel != nil {
 		labels[*data.NameLabel] = data.Name
 	}

--- a/microlith/html/promwebform.html
+++ b/microlith/html/promwebform.html
@@ -213,7 +213,7 @@
                       (node) => `${node}:${this.exporterPort}`
                     ),
                     labels: {
-                      cluster: this.name,
+                      cluster_label: this.name,
                     },
                   },
                 ],
@@ -227,6 +227,7 @@
               });
               this.healthcheckCommand = `curl -u ${this.cbmmUsername}:${this.cbmmPassword} -X POST -d '${serverConfig}' 'http://localhost/api/v1/clusters'`;
             },
+
             async configure() {
               this.error = "";
               this.success = false;
@@ -243,10 +244,9 @@
                       targets: this.nodes.map(
                         (node) => `${node}:${this.exporterPort}`
                       ),
-                      labels: {
-                        cluster: this.name,
-                      },
+                      labels: {},
                       overwrite: this.overwrite,
+                      nameLabel: "cluster_label",
                     }),
                   })
                     .then(async (resp) => {


### PR DESCRIPTION
The add cluster form sets a label called `cluster` which is the name the user gives it, but the Exporter also exposes a field called `cluster` which is the name of the cluster as given to CB. This commit changes the name of the field added by the form to `cluster_label`. (I didn't use `cluster_name` as the Cluster Monitor uses that name for its metrics - they're on a different job, so they wouldn't get clobbered, but the names would still be inconsistent.)