### PR TITLE
CMOS-139: Update base images

### DIFF
--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -1,8 +1,8 @@
-FROM grafana/grafana:8.1.1 as grafana-official
+FROM grafana/grafana:8.2.3 as grafana-official
 FROM grafana/loki:2.3.0 as loki-official
-FROM prom/prometheus:v2.28.1 as prometheus-official
-FROM prom/alertmanager:v0.22.2 as alertmanager-official
-FROM jaegertracing/all-in-one:1.25.0 as jaegaer-official
+FROM prom/prometheus:v2.31.0 as prometheus-official
+FROM prom/alertmanager:v0.23.0 as alertmanager-official
+FROM jaegertracing/all-in-one:1.27.0 as jaegaer-official
 
 FROM golang:1.17 as builder
 # Builder image so ignore pinning and we do want recommended packages
@@ -41,7 +41,6 @@ RUN go mod download && \
     CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbmultimanager ./cluster-monitor/cmd/cbmultimanager && \
     CGO_ENABLED=1 GOOS=linux go build -trimpath -a -ldflags '-linkmode external -extldflags "-static"' -o /bin/cbeventlog ./cluster-monitor/cmd/cbeventlog
 
-# TODO: golang17 version once available
 FROM node:16-alpine3.14 as ui-builder
 
 # Just copy over rather than clone


### PR DESCRIPTION
Changelogs:
* Prometheus 2.28.1 -> 2.31.0: https://github.com/prometheus/prometheus/blob/release-2.31/CHANGELOG.md
* Alertmanager 0.22.2 -> 0.23.0: https://github.com/prometheus/alertmanager/blob/release-0.23/CHANGELOG.md
* Grafana 8.1.1 -> 8.2.3: https://github.com/grafana/grafana/blob/v8.2.3/CHANGELOG.md
* Jaeger 1.25.0 -> 1.27.0: https://github.com/jaegertracing/jaeger/blob/v1.27.0/CHANGELOG.md

Ran the tests, and also verified that all core functions work after running the built image manually.