### PR TITLE
CMOS-131 Remove cluster name label

### DIFF
--- a/microlith/html/promwebform.html
+++ b/microlith/html/promwebform.html
@@ -10,18 +10,6 @@
       <form name="inputForm" id="inputForm">
         <fieldset>
           <div>
-            <label for="name"><strong>Cluster Name:</strong></label>
-            <input
-              type="text"
-              name="name"
-              x-model="name"
-              required
-              pattern="[a-zA-Z_][a-zA-Z0-9_]*"
-              title="Permitted: ASCII letters, numbers, underscores."
-            />
-            <em>Permitted: ASCII letters, numbers, underscores.</em>
-          </div>
-          <div>
             <label for="serverUser">Couchbase Server Username:</label>
             <input
               type="text"
@@ -138,15 +126,8 @@
         <h2>Prometheus configuration</h2>
         <p>
           Save the below JSON to a file and place it in
-          <code
-            >/etc/prometheus/couchbase/custom/<span x-text="name"></span
-            >.json</code
-          >. For example:
-          <code
-            >docker cp <span x-text="name"></span>.json
-            cmos:/etc/prometheus/couchbase/custom/<span x-text="name"></span
-            >.json</code
-          >
+          <code>/etc/prometheus/couchbase/custom/cluster-name.json</code>. For example:
+          <code>docker cp cluster-name.json cmos:/etc/prometheus/couchbase/custom/cluster-name.json</code>
           (substitute <code>cmos</code> for the name of your running container).
           Once saved, check the "Targets" page in Prometheus to see if it has
           picked it up. If it does not, wait 30-60 seconds and check again, as
@@ -183,7 +164,6 @@
       document.addEventListener("alpine:init", function () {
         Alpine.data("generator", function () {
           return {
-            name: "",
             nodes: [""],
             overwrite: false,
 
@@ -212,9 +192,7 @@
                     targets: this.nodes.map(
                       (node) => `${node}:${this.exporterPort}`
                     ),
-                    labels: {
-                      cluster_label: this.name,
-                    },
+                    labels: {},
                   },
                 ],
                 null,
@@ -240,13 +218,13 @@
                       "Content-Type": "application/json",
                     },
                     body: JSON.stringify({
-                      name: this.name,
+                      // Remove all characters invalid in file names
+                      name: this.nodes[0].replace(/[^a-zA-Z0-9\-_.]/g, "-"),
                       targets: this.nodes.map(
                         (node) => `${node}:${this.exporterPort}`
                       ),
                       labels: {},
                       overwrite: this.overwrite,
-                      nameLabel: "cluster_label",
                     }),
                   })
                     .then(async (resp) => {


### PR DESCRIPTION
The `cluster` label on the `couchbase-server` jobs is unnecessary - the Exporter sets a label `cluster` and cbmultimanager sets `cluster_name` and `cluster_uuid`. If we set one at the job level it'll get clobbered or renamed to `exported_cluster` which may break the dashboards.

Remove the field entirely to avoid the need to keep around various versions of it. The generated Prometheus targets file will be named after the first node in the cluster (sanitised for a file name).

We may need to revisit this when we move to CB7's Prometheus, as I don't think it sets a `cluster` label - but for now this should be sufficient.