### PR TITLE
CMOS-144: Remove navigation links to Cluster Monitor UI

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -9,6 +9,5 @@
 
 .Tooling
 * link:http://localhost:8080/alertmanager/[Alert Manager]
-* link:http://localhost:8080/couchbase/ui/[Couchbase Cluster Monitor]
 * link:http://localhost:8080/grafana/[Grafana]
 * link:http://localhost:8080/prometheus/[Prometheus]

--- a/microlith/html/index.html
+++ b/microlith/html/index.html
@@ -22,7 +22,6 @@
     <li><a id="prometheus" href="prometheus/">Prometheus</a></li>
     <li><a id="jaeger" href="jaeger/">Jaeger</a></li>
     <li><a id="alertmanager" href="alertmanager/">Alert Manager</a></li>
-    <li><a id="couchbase" href="couchbase/ui/">Couchbase Cluster Monitor</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
For v0.1 we're not going to have the UI as a feature - it'll still be there in case we need to debug the cluster monitor's behaviour, but it won't be user-facing. Remove the links from our navigation - both on the HTML landing page and in Antora.