### PR TITLE
Update quick start guide for Add Cluster renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We essentially need to support two fairly distinct types of user:
 5. Build the container: `make container` if you want to include the Cluster Monitor or `make container-oss` otherwise
 6. Run the container: `docker run --rm -d -p 8080:8080 --name cmos couchbase/observability-stack:v1` (if your Couchbase Server is running in Docker, you may need to set [extra options](https://docs.docker.com/network/) to permit them to communicate.)
 7. Browse to http://localhost:8080
-8. Click "Prometheus Add Endpoint" and follow the instructions
+8. Click "Add Cluster" and follow the instructions
 
 When you are done testing, run `docker stop cmos` to clean up.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -22,7 +22,7 @@ We essentially need to support two fairly distinct types of user:
 . Build the container: `make container` if you want to include the Cluster Monitor or `make container-oss` otherwise
 . Run the container: `docker run --rm -d -p 8080:8080 --name cmos couchbase/observability-stack:v1` (if your Couchbase Server is running in Docker, you may need to set https://docs.docker.com/network/[extra options] to permit them to communicate.)
 . Browse to http://localhost:8080
-. Click "Prometheus Add Endpoint" and follow the instructions
+. Click "Add Cluster" and follow the instructions
 
 When you are done testing, run `docker stop cmos` to clean up.
 


### PR DESCRIPTION
In https://github.com/couchbaselabs/observability/commit/de00a275776997318dc74f696e9a8cdb79e86fc5 we renamed "Prometheus Add Endpoint" to "Add Cluster". Update the quick start guide in the README to match.