### PR TITLE
CMOS-12, CMOS-52, CMOS-92: Rework cbmultimanager inclusion process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ tools/tern/
 tools/tern-output*
 # config-svc build
 microlith/config-svc
+# cluster monitor build
+microlith/cluster-monitor
 # Test
 *-actual.yaml
 microlith/Dockerfile.oss

--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -31,7 +31,7 @@ RUN go mod download && \
 # Couchbase proprietary start
 # Standalone as need to use --mount option
 WORKDIR /src/github.com/couchbaselabs/cbmultimanager
-RUN --mount=type=ssh git clone --depth 1 git@github.com:couchbaselabs/cbmultimanager.git /src/github.com/couchbaselabs/cbmultimanager/
+COPY cluster-monitor/ .
 
 # Output our commit information to a file we can access
 RUN git rev-parse HEAD > /etc/couchbase/git-commit.txt


### PR DESCRIPTION
Previously we would get the private cbmultimanager repo by performing a Git SSH bind mount in the Dockerfile. This had a couple serious issues: you needed to have a local SSH agent running, it requires BuildKit (though that's less of an issue these days), and the only version you could build was master.

This commit switches the process to doing something akin to the config-svc build process: the cbmultimanager source is cloned by the Makefile, then handed over to Docker which builds it from the local clone. This also means the version to use can be specified as a Makefile parameter.

In future we may switch this to use the manifests system used by other CB products - hopefully the Dockerfile change would make this easier by doing some of the groundwork in advance.