### PR TITLE
CMOS-143: Add improved CB7 single-cluster overview dashboard

### DIFF
--- a/microlith/grafana/provisioning/dashboards/couchbase-inventory.json
+++ b/microlith/grafana/provisioning/dashboards/couchbase-inventory.json
@@ -239,7 +239,7 @@
                   {
                     "targetBlank": false,
                     "title": "Cluster overview dashboard",
-                    "url": "/grafana/d/cL8993dnz/single-cluster-overview?var-cluster=${__data.fields.Name}"
+                    "url": "/grafana/d/UEZRQMc7z/single-cluster-overview?var-cluster=${__data.fields.Name}"
                   }
                 ]
               }

--- a/microlith/grafana/provisioning/dashboards/single-cluster-overview-7.json
+++ b/microlith/grafana/provisioning/dashboards/single-cluster-overview-7.json
@@ -19,11 +19,13 @@
     ]
   },
   "editable": true,
+  "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 2,
-  "id": 4,
-  "iteration": 1635786860242,
+  "id": 2,
+  "iteration": 1636552598772,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -40,7 +42,7 @@
       "type": "row"
     },
     {
-      "datasource": "JSON API",
+      "datasource": "-- Mixed --",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -69,18 +71,6 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Services"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 312
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
               "options": "CPUs"
             },
             "properties": [
@@ -98,7 +88,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 112
+                "value": 97
               }
             ]
           },
@@ -113,12 +103,56 @@
                 "value": 123
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Health Check Warnings"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 167
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Version"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 154
+              }
+            ]
           }
         ]
       },
       "gridPos": {
         "h": 8,
-        "w": 15,
+        "w": 12,
         "x": 0,
         "y": 1
       },
@@ -127,15 +161,16 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.2.3",
       "targets": [
         {
-          "cacheDurationSeconds": 30,
+          "cacheDurationSeconds": 0,
+          "datasource": "JSON API",
           "fields": [
             {
               "jsonPath": "$map($.nodes_summary[*].host, function($h) {\n    $replace(\n      $replace($h, /:\\d+$/, \"\")\n    , /https?:\\/\\//, \"\")\n})",
               "language": "jsonata",
-              "name": "Hostname"
+              "name": "hostname"
             },
             {
               "jsonPath": "$map($.nodes_summary[*].version, function($m) {$join($append($split($m, \"-\")[0], $replace($split($m, \"-\")[2], \"e\", \"E\", 1)), \" \")})",
@@ -172,13 +207,47 @@
           "queryParams": "",
           "refId": "A",
           "urlPath": "/clusters/$cluster_uuid"
+        },
+        {
+          "datasource": "Prometheus",
+          "exemplar": true,
+          "expr": "max by (hostname) (label_replace(multimanager_node_checker_status{cluster_name=\"$cluster\"} > 0, \"hostname\", \"$1\", \"node_name\", \"(.+)(:[0-9]+)$\"))",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
         }
       ],
       "title": "Nodes",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Health Check Warnings",
+              "hostname": "Hostname"
+            }
+          }
+        }
+      ],
       "type": "table"
     },
     {
-      "datasource": "JSON API",
+      "datasource": "-- Mixed --",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -251,28 +320,94 @@
                 "value": 121
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active Resident Ratio"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "custom.width",
+                "value": 159
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Health Check Warnings"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              },
+              {
+                "id": "noValue",
+                "value": "0"
+              },
+              {
+                "id": "custom.width",
+                "value": 187
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "# Indexes"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 113
+              }
+            ]
           }
         ]
       },
       "gridPos": {
         "h": 8,
-        "w": 9,
-        "x": 15,
+        "w": 12,
+        "x": 12,
         "y": 1
       },
-      "id": 4,
+      "id": 48,
       "options": {
+        "frameIndex": 1,
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.2.3",
       "targets": [
         {
           "cacheDurationSeconds": 30,
+          "datasource": "JSON API",
           "fields": [
             {
               "jsonPath": "$.buckets_summary[*].name",
-              "name": "Name"
+              "name": "bucket"
             },
             {
               "jsonPath": "$map($.buckets_summary[*], function($b) {\n  $formatNumber($b.items, \"#,###\")\n})",
@@ -298,26 +433,88 @@
           ],
           "method": "GET",
           "queryParams": "",
-          "refId": "A",
+          "refId": "BaseData",
           "urlPath": "/clusters/$cluster_uuid"
+        },
+        {
+          "cacheDurationSeconds": 300,
+          "datasource": "Prometheus",
+          "exemplar": true,
+          "expr": "count by (bucket) (index_items_count{cluster=`$cluster`}) or max by (bucket) (clamp_max(kv_ops, 0))",
+          "fields": [
+            {
+              "jsonPath": ""
+            }
+          ],
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "method": "GET",
+          "queryParams": "",
+          "refId": "NumIndexes",
+          "urlPath": ""
+        },
+        {
+          "datasource": "Prometheus",
+          "exemplar": true,
+          "expr": "count by (bucket) (multimanager_bucket_checker_status{cluster_name=`$cluster`} > 0)",
+          "format": "table",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "CheckWarnings"
+        },
+        {
+          "datasource": "Prometheus",
+          "exemplar": true,
+          "expr": "min by (bucket) (kv_vb_perc_mem_resident_ratio{cluster=`$cluster`,state=\"active\"})",
+          "format": "table",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "ResidentRatio"
         }
       ],
-      "title": "Buckets",
+      "title": "Dataset",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "bucket"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Items Stored": 1,
+              "Quota": 2,
+              "Quota Used": 3,
+              "Replicas": 5,
+              "Time": 6,
+              "Value #CheckWarnings": 8,
+              "Value #NumIndexes": 7,
+              "Value #ResidentRatio": 4,
+              "bucket": 0
+            },
+            "renameByName": {
+              "Value #CheckWarnings": "Health Check Warnings",
+              "Value #NumIndexes": "# Indexes",
+              "Value #ResidentRatio": "Active Resident Ratio"
+            }
+          }
+        }
+      ],
       "type": "table"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "id": 12,
-      "panels": [],
-      "title": "Health Checks",
-      "type": "row"
     },
     {
       "datasource": null,
@@ -440,35 +637,51 @@
                 ]
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 228
+              }
+            ]
           }
         ]
       },
       "gridPos": {
-        "h": 12,
-        "w": 8,
+        "h": 5,
+        "w": 5,
         "x": 0,
-        "y": 10
+        "y": 9
       },
       "id": 6,
       "options": {
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.2.3",
       "targets": [
         {
           "exemplar": true,
-          "expr": "multimanager_cluster_checker_status{cluster_uuid=\"$cluster_uuid\"}",
+          "expr": "multimanager_cluster_checker_status{cluster_uuid=\"$cluster_uuid\"} > 0",
           "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Cluster Check Status",
+      "title": "Cluster Health Issues",
       "transformations": [
         {
           "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "merge",
           "options": {}
         },
         {
@@ -502,614 +715,17 @@
       "type": "table"
     },
     {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "filterable": false
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "Good"
-                },
-                "1": {
-                  "color": "orange",
-                  "index": 1,
-                  "text": "Warn"
-                },
-                "2": {
-                  "color": "red",
-                  "index": 2,
-                  "text": "Alert"
-                },
-                "3": {
-                  "index": 3,
-                  "text": "Info"
-                },
-                "4": {
-                  "index": 4,
-                  "text": "Missing"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              },
-              {
-                "color": "text",
-                "value": 3
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value"
-            },
-            "properties": [
-              {
-                "id": "custom.displayMode",
-                "value": "color-background"
-              },
-              {
-                "id": "links",
-                "value": [
-                  {
-                    "title": "Details",
-                    "url": "http://localhost:8080/couchbase/ui/clusters/${cluster_uuid:queryparam}/status"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "State"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 120
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ID"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 100
-              },
-              {
-                "id": "links",
-                "value": [
-                  {
-                    "targetBlank": true,
-                    "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/cmos/cmos/0.1/couchbase-cluster-monitor/checkers.html#${__data.fields.ID}"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 223
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Node"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 239
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 8,
-        "x": 8,
-        "y": 10
-      },
-      "id": 7,
-      "options": {
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "8.1.1",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "multimanager_node_checker_status{cluster_uuid=\"$cluster_uuid\"} > 0",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Node Check Warnings",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "cluster_name": true,
-              "cluster_uuid": true,
-              "instance": true,
-              "job": true,
-              "node_uuid": true
-            },
-            "indexByName": {
-              "Time": 0,
-              "Value": 8,
-              "cluster_name": 2,
-              "cluster_uuid": 3,
-              "id": 5,
-              "instance": 6,
-              "job": 7,
-              "name": 4,
-              "node_name": 1,
-              "node_uuid": 9
-            },
-            "renameByName": {
-              "Value": "State",
-              "id": "ID",
-              "name": "Name",
-              "node_name": "Node",
-              "node_uuid": ""
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "filterable": false
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "Good"
-                },
-                "1": {
-                  "color": "orange",
-                  "index": 1,
-                  "text": "Warn"
-                },
-                "2": {
-                  "color": "red",
-                  "index": 2,
-                  "text": "Alert"
-                },
-                "3": {
-                  "index": 3,
-                  "text": "Info"
-                },
-                "4": {
-                  "index": 4,
-                  "text": "Missing"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              },
-              {
-                "color": "text",
-                "value": 3
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value"
-            },
-            "properties": [
-              {
-                "id": "custom.displayMode",
-                "value": "color-background"
-              },
-              {
-                "id": "links",
-                "value": [
-                  {
-                    "title": "Details",
-                    "url": "http://localhost:8080/couchbase/ui/clusters/${cluster_uuid:querystring}/status"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "State"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 120
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ID"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 100
-              },
-              {
-                "id": "links",
-                "value": [
-                  {
-                    "targetBlank": true,
-                    "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/cmos/cmos/0.1/couchbase-cluster-monitor/checkers.html#${__data.fields.ID}"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 6,
-        "x": 16,
-        "y": 10
-      },
-      "id": 8,
-      "options": {
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "8.1.1",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "multimanager_bucket_checker_status{cluster_uuid=\"$cluster_uuid\"} > 0",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Bucket Check Warnings",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "cluster_name": true,
-              "cluster_uuid": true,
-              "instance": true,
-              "job": true,
-              "node_uuid": true
-            },
-            "indexByName": {
-              "Time": 1,
-              "bucket": 0,
-              "cluster_name": 2,
-              "cluster_uuid": 3,
-              "id": 5,
-              "instance": 6,
-              "job": 7,
-              "multimanager_bucket_checker_status{bucket=\"pillowfight\", cluster_name=\"CMOS Test Cluster\", cluster_uuid=\"015064e58e979ec589c9ca85e799695d\", id=\"CB90013\", instance=\"localhost:7196\", job=\"couchbase-cluster-monitor\", name=\"residentRatioTooLow\"}": 8,
-              "name": 4
-            },
-            "renameByName": {
-              "Value": "State",
-              "id": "ID",
-              "multimanager_bucket_checker_status{bucket=\"charlie\", cluster_name=\"Dev Kicks with 6.6\", cluster_uuid=\"1854ec0786317e83b4302bbee5fbdc6d\", id=\"CB90010\", instance=\"localhost:7196\", job=\"couchbase-cluster-monitor\", name=\"missingReplicaVBuckets\"}": "State",
-              "name": "Name",
-              "node_name": "Node"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.7
-              },
-              {
-                "color": "#6ED0E0",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 22,
-        "y": 10
-      },
-      "id": 10,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.1.1",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "(\ncount(multimanager_cluster_checker_status{cluster_uuid=\"$cluster_uuid\"} == 0) + \ncount(multimanager_node_checker_status{cluster_uuid=\"$cluster_uuid\"} == 0) + \ncount(multimanager_bucket_checker_status{cluster_uuid=\"$cluster_uuid\"} == 0)\n) / (\ncount(multimanager_cluster_checker_status{cluster_uuid=\"$cluster_uuid\"}) +\ncount(multimanager_node_checker_status{cluster_uuid=\"$cluster_uuid\"}) +\ncount(multimanager_bucket_checker_status{cluster_uuid=\"$cluster_uuid\"})\n)",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Passing Health Checks",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 0,
-                  "text": "No"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 1,
-                  "text": "Yes"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 2,
-        "x": 22,
-        "y": 13
-      },
-      "id": 39,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.1.1",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "floor(\nmin(sum by (instance) (cbnode_healthy{cluster=${cluster:doublequote}})) / \nmax(sum by (instance) (cbnode_cluster_membership{cluster=${cluster:doublequote}}))\n)",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "All Nodes Healthy",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "green",
-                "value": 3
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 22,
-        "y": 18
-      },
-      "id": 40,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.1.1",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "max(count by (instance) (cbnode_healthy{cluster=${cluster:doublequote}} == 1))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Healthy Nodes",
-      "type": "stat"
-    },
-    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 14
       },
       "id": 16,
       "panels": [],
-      "title": "KPIs",
+      "title": "KPIs - KV",
       "type": "row"
     },
     {
@@ -1117,193 +733,55 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
+                "color": "green",
                 "value": null
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 2,
+        "h": 8,
+        "w": 7,
         "x": 0,
-        "y": 23
-      },
-      "id": 18,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^Connections$/",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.1.1",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum by (cluster) (cbpernodebucket_curr_connections{cluster=${cluster:doublequote}})",
-          "interval": "",
-          "legendFormat": "Connections",
-          "refId": "A"
-        }
-      ],
-      "title": "Active Connections",
-      "transformations": [],
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 2,
-        "y": 23
-      },
-      "id": 37,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum by (instance) (cbpernodebucket_ops{cluster=${cluster:doublequote}})",
-          "interval": "",
-          "legendFormat": "{{ instance }}",
-          "refId": "A"
-        }
-      ],
-      "title": "Total KV Ops",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 8,
-        "y": 23
+        "y": 15
       },
       "id": 28,
       "options": {
@@ -1319,7 +797,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (cluster, instance) (cbbucketstat_cmd_get{cluster=${cluster:doublequote}})",
+          "expr": "sum by (instance) (rate(kv_ops{cluster=\"$cluster\",op=\"get\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "{{ instance}}",
           "refId": "A"
@@ -1379,9 +857,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 5,
-        "x": 13,
-        "y": 23
+        "w": 7,
+        "x": 7,
+        "y": 15
       },
       "id": 29,
       "options": {
@@ -1397,7 +875,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (cluster, instance) (cbbucketstat_cmd_set{cluster=${cluster:doublequote}})",
+          "expr": "sum by (instance) (rate(kv_ops{cluster=`$cluster`,op=~\"set.*\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "{{ instance}}",
           "refId": "A"
@@ -1455,17 +933,17 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 23
+        "w": 7,
+        "x": 14,
+        "y": 15
       },
-      "id": 31,
+      "id": 46,
       "options": {
         "legend": {
           "calcs": [],
@@ -1479,70 +957,194 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg by (bucket) (cbbucketstat_ep_cache_miss_rate{cluster=${cluster:doublequote}})",
+          "expr": "histogram_quantile(0.99, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster=`$cluster`,opcode=\"GET\"}[5m])))",
+          "instant": false,
           "interval": "",
           "legendFormat": "{{bucket}}",
           "refId": "A"
         }
       ],
-      "title": "Cache Miss Rate",
+      "title": "Reads 99th Percentile",
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "JSON API",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 0,
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
+                "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 79
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SDK/Client Version"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 174
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 4,
-        "w": 2,
+        "h": 6,
+        "w": 14,
         "x": 0,
-        "y": 27
+        "y": 23
       },
-      "id": 22,
+      "id": 39,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
+        "showHeader": true,
+        "sortBy": []
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.2.3",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum by (cluster) (cbbucketstat_curr_items_tot{cluster=${cluster:doublequote}})",
-          "interval": "",
-          "legendFormat": "{{cluster}}",
-          "refId": "A"
+          "cacheDurationSeconds": 30,
+          "fields": [
+            {
+              "jsonPath": "$.connections[*].sdk_name",
+              "name": "SDK/Client"
+            },
+            {
+              "jsonPath": "$.connections[*].sdk_version",
+              "language": "jsonpath",
+              "name": "SDK Version"
+            },
+            {
+              "jsonPath": "$.connections.user.($ = null ? \"\" : $replace($.name, /<\\/?ud>/, \"\"))",
+              "language": "jsonata",
+              "name": "Username"
+            },
+            {
+              "jsonPath": "$.connections[*].source.ip",
+              "language": "jsonpath",
+              "name": "Source IP"
+            },
+            {
+              "jsonPath": "$.connections[*].agent_name",
+              "language": "jsonpath",
+              "name": ""
+            }
+          ],
+          "method": "GET",
+          "queryParams": "",
+          "refId": "A",
+          "urlPath": "/clusters/$cluster_uuid/connections"
         }
       ],
-      "title": "Items Stored",
-      "type": "stat"
+      "title": "Connected KV Clients",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "SDK Version": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "SDK/Client": {
+                "aggregations": [
+                  "first",
+                  "count"
+                ],
+                "operation": "aggregate"
+              },
+              "Source IP": {
+                "aggregations": [
+                  "allValues"
+                ],
+                "operation": "aggregate"
+              },
+              "Username": {
+                "aggregations": [
+                  "allValues"
+                ],
+                "operation": "aggregate"
+              },
+              "agent_name": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "agent_name": true
+            },
+            "indexByName": {
+              "SDK Version (first)": 2,
+              "SDK/Client (count)": 3,
+              "SDK/Client (first)": 1,
+              "Source IP (allValues)": 5,
+              "Username (allValues)": 4,
+              "agent_name": 0
+            },
+            "renameByName": {
+              "SDK Version (first)": "SDK/Client Version",
+              "SDK/Client (count)": "Count",
+              "SDK/Client (first)": "SDK/Client",
+              "Source IP (allValues)": "Source IPs",
+              "Username (allValues)": "Usernames"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 41,
+      "panels": [],
+      "title": "KPIs - N1QL",
+      "type": "row"
     },
     {
       "datasource": null,
@@ -1592,15 +1194,16 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 5,
+        "w": 7,
         "x": 0,
-        "y": 31
+        "y": 30
       },
       "id": 20,
       "options": {
@@ -1616,7 +1219,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "cbquery_requests{cluster=${cluster:doublequote}}",
+          "expr": "sum by (instance) (rate(n1ql_requests{cluster=\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -1670,15 +1273,15 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ns"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 5,
-        "x": 5,
-        "y": 31
+        "w": 7,
+        "x": 7,
+        "y": 30
       },
       "id": 24,
       "options": {
@@ -1691,10 +1294,12 @@
           "mode": "single"
         }
       },
+      "pluginVersion": "8.2.3",
       "targets": [
         {
           "exemplar": true,
-          "expr": "cbquery_avg_req_time{cluster=${cluster:doublequote}}",
+          "expr": "increase(n1ql_request_time[$__rate_interval]) / increase(n1ql_requests[$__rate_interval])",
+          "instant": false,
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -1702,6 +1307,20 @@
       ],
       "title": "Average Query Execution Time",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 43,
+      "panels": [],
+      "title": "KPIs - GSI",
+      "type": "row"
     },
     {
       "datasource": null,
@@ -1763,8 +1382,8 @@
       "gridPos": {
         "h": 8,
         "w": 7,
-        "x": 10,
-        "y": 31
+        "x": 0,
+        "y": 39
       },
       "id": 33,
       "options": {
@@ -1780,7 +1399,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "cbindex_memory_used{cluster=${cluster:doublequote}} / cbindex_memory_quota{cluster=${cluster:doublequote}}",
+          "expr": "index_memory_used_total{cluster=${cluster:doublequote}} / index_memory_quota{cluster=${cluster:doublequote}}",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -1813,8 +1432,8 @@
       "gridPos": {
         "h": 8,
         "w": 7,
-        "x": 17,
-        "y": 31
+        "x": 7,
+        "y": 39
       },
       "id": 35,
       "options": {
@@ -1830,21 +1449,80 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.2.3",
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(4, cbindex_avg_scan_latency{cluster=${cluster:doublequote}})",
+          "expr": "topk(4, index_avg_scan_latency{cluster=${cluster:doublequote}})",
+          "instant": true,
           "interval": "",
-          "legendFormat": "{{keyspace}} @ {{instance}}",
+          "legendFormat": "{{index}}",
           "refId": "A"
         }
       ],
       "title": "Slowest Scanning Indexes",
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 14,
+        "y": 39
+      },
+      "id": 44,
+      "options": {
+        "displayMode": "basic",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "topk(4, index_data_size{cluster=${cluster:doublequote}})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{index}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Largest Indexes",
+      "transformations": [],
       "type": "bargauge"
     }
   ],
-  "schemaVersion": 30,
+  "refresh": "15s",
+  "schemaVersion": 31,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1853,8 +1531,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "CMOS Test Cluster",
-          "value": "CMOS Test Cluster"
+          "text": "CMOS 7 Test",
+          "value": "CMOS 7 Test"
         },
         "datasource": null,
         "definition": "label_values(multimanager_cluster_checker_status,cluster_name)",
@@ -1880,8 +1558,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "015064e58e979ec589c9ca85e799695d",
-          "value": "015064e58e979ec589c9ca85e799695d"
+          "text": "7ce7c09b3514e83792724b8a530b66e0",
+          "value": "7ce7c09b3514e83792724b8a530b66e0"
         },
         "datasource": null,
         "definition": "multimanager_cluster_checker_status{cluster_name=\"$cluster\"}",
@@ -1906,7 +1584,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {
@@ -1923,7 +1601,7 @@
     ]
   },
   "timezone": "",
-  "title": "Single Cluster Information (6.x)",
-  "uid": "cL8993dnz",
+  "title": "Single Cluster Information (7.x)",
+  "uid": "UEZRQMc7z",
   "version": 1
 }


### PR DESCRIPTION
This commit adds a version of the single-cluster-overview dashboard compatible with CBS 7.x. It keeps around the 6.x version for the time being, but the Couchbase Inventory will now link to 7.x.

This PR is independent of #79, though testing it will require configuring CMOS the "old-fashioned way" (i.e. `docker cp`, not the GUI) until that PR is merged.

![image](https://user-images.githubusercontent.com/2904440/141127779-929956ed-e57d-44de-8c94-29d920d82247.png)
