### PR TITLE
Add prerequisites to quick-start guide

### DIFF
--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -1,7 +1,9 @@
 = Quick Start
 
-. Ensure you have a Couchbase Server cluster running and accessible - for testing we recommend using https://github.com/couchbaselabs/vagrants[Vagrant^] or https://docs.couchbase.com/cloud-native-database/containers/docker-basic-install.html[Docker^]
-. Ensure you have the https://github.com/couchbase/couchbase-exporter[Couchbase Prometheus Exporter^] set up on each of your Couchbase Server nodes
+You will need a Docker daemon - on Linux use your respective package manager, on macOS or Windows you can use https://www.docker.com/products/docker-desktop[Docker Desktop^].
+
+You will also need a Couchbase Server cluster running and accessible - for testing we recommend using https://github.com/couchbaselabs/vagrants[Vagrant^] or https://docs.couchbase.com/cloud-native-database/containers/docker-basic-install.html[Docker^]. If you are using Couchbase Server 6.6, you will need the https://github.com/couchbase/couchbase-exporter[Couchbase Prometheus Exporter^] set up on each of your Couchbase Server nodes.
+
 . Clone the couchbaselabs/observability repo: `git clone git@github.com:couchbaselabs/observability.git`
 . Part of CMOS is the proprietary Couchbase Cluster Monitor, in https://github.com/couchbaselabs/cbmultimanager[this private repository^]. If you want to build CMOS to use it, https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent[set up your local SSH agent^].
 . Build the container: `make container` if you want to include the Cluster Monitor or `make container-oss` otherwise


### PR DESCRIPTION
The QSG never actually says that you need Docker, it's implied. Explicitly add it.