### PR TITLE
Tweak dashboard interlinking

### DIFF
--- a/microlith/grafana/provisioning/dashboards/couchbase-inventory.json
+++ b/microlith/grafana/provisioning/dashboards/couchbase-inventory.json
@@ -22,8 +22,22 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
-  "links": [],
+  "id": 5,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Add Cluster",
+      "tooltip": "",
+      "type": "link",
+      "url": "/public/cmos-doc-redirect.html#/promwebform.html"
+    }
+  ],
+  "liveNow": false,
   "panels": [
     {
       "datasource": "JSON API",
@@ -320,14 +334,17 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 30,
+  "schemaVersion": 31,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "couchbase",
+    "couchbase-inventory"
+  ],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},

--- a/microlith/grafana/provisioning/dashboards/single-cluster-overview-7.json
+++ b/microlith/grafana/provisioning/dashboards/single-cluster-overview-7.json
@@ -22,9 +22,24 @@
   "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 2,
-  "id": 2,
-  "iteration": 1636552598772,
-  "links": [],
+  "id": 6,
+  "iteration": 1636626119419,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "couchbase-inventory"
+      ],
+      "targetBlank": false,
+      "title": "Couchbase Inventory",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -1603,5 +1618,5 @@
   "timezone": "",
   "title": "Single Cluster Information (7.x)",
   "uid": "UEZRQMc7z",
-  "version": 1
+  "version": 2
 }

--- a/microlith/grafana/provisioning/dashboards/single-cluster-overview.json
+++ b/microlith/grafana/provisioning/dashboards/single-cluster-overview.json
@@ -19,10 +19,11 @@
     ]
   },
   "editable": true,
+  "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 2,
-  "id": 4,
-  "iteration": 1635786860242,
+  "id": 6,
+  "iteration": 1636626119419,
   "links": [
     {
       "asDropdown": false,

--- a/microlith/grafana/provisioning/dashboards/single-cluster-overview.json
+++ b/microlith/grafana/provisioning/dashboards/single-cluster-overview.json
@@ -23,7 +23,22 @@
   "graphTooltip": 2,
   "id": 4,
   "iteration": 1635786860242,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "couchbase-inventory"
+      ],
+      "targetBlank": false,
+      "title": "Couchbase Inventory",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "panels": [
     {
       "collapsed": false,


### PR DESCRIPTION
- Add link to Add Cluster page on the inventory dashboard
- Add tags to the inventory dashboard, and link back to it from the single-cluster dashboards

![interlinking-1](https://user-images.githubusercontent.com/2904440/141281946-2cce9ffa-3f7c-42f4-912d-253c56c2830c.jpg)
![interlinking-2](https://user-images.githubusercontent.com/2904440/141281942-72f81cd9-cc99-4d7e-beb9-bacb3adbc341.jpg)



