### PR TITLE
Container example updates

### DIFF
--- a/examples/containers/.env
+++ b/examples/containers/.env
@@ -1,0 +1,3 @@
+SERVER_IMAGE=couchbase/server:7.0.2
+FLUENT_BIT_IMAGE=couchbase/fluent-bit:1.1.2
+CMOS_IMAGE=registry.gitlab.com/cb-vanilla/observability-stack:latest

--- a/examples/containers/.env
+++ b/examples/containers/.env
@@ -1,3 +1,3 @@
-SERVER_IMAGE=couchbase/server:7.0.2
+COUCHBASE_SERVER_IMAGE=couchbase/server:7.0.2
 FLUENT_BIT_IMAGE=couchbase/fluent-bit:1.1.2
 CMOS_IMAGE=registry.gitlab.com/cb-vanilla/observability-stack:latest

--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -2,13 +2,9 @@ An example of using the microlith image locally.
 
 To run a full stack use the `Makefile` at the top of this repo and just execute the target: `make example-containers`
 
-This uses an SSH mount to access a private git repository during the container build so make sure your SSH keys are set up for git locally and ssh agent is running with them to provide it.
-
-This will spin up a Couchbase cluster (single node) with Prometheus exporter.
-It will also build and start the all-in-one observability container and configure it to talk to the cluster automatically.
+This will spin up a Couchbase cluster (single node) and CMOS.
+The `Add Cluster` page can be used to add the `db1` host with default credentials of `Administrator:password`.
 
 Add additional clusters by running up a new Couchbase Server image and either attaching it to an existing cluster or creating a new one.
-
-For Linux, make sure to enable the CLI tech preview for docker compose: https://docs.docker.com/compose/cli-command/
 
 It demonstrates how to mount in custom rules and end points to scrape.

--- a/examples/containers/configure-cbs.sh
+++ b/examples/containers/configure-cbs.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eu
+
+echo "Overriding CBS entrypoint as this gives us declarative control"
+
+# Clean up old logs and make sure we have directories we need
+rm -rf /opt/couchbase/var/lib/couchbase/logs/*
+mkdir -p /opt/couchbase/var/lib/couchbase/{config,data,stats,logs}
+
+echo "Run up Couchbase Server"
+/opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput &
+
+echo "Wait for it to be ready"
+until curl -sS -w 200 http://127.0.0.1:8091/ui/index.html &> /dev/null; do
+    echo "Not ready, waiting to recheck"
+    sleep 2
+done
+
+echo "Configuring cluster"
+couchbase-cli cluster-init -c 127.0.0.1 \
+    --cluster-username Administrator \
+    --cluster-password password \
+    --services data,index,query,fts,analytics \
+    --cluster-ramsize 2048 \
+    --cluster-index-ramsize 1024 \
+    --cluster-eventing-ramsize 1024 \
+    --cluster-fts-ramsize 1024 \
+    --cluster-analytics-ramsize 1024 \
+    --cluster-fts-ramsize 1024 \
+    --cluster-name "CMOS container test" \
+    --index-storage-setting default
+
+echo "Enable audit logging"
+couchbase-cli setting-audit -c 127.0.0.1 \
+    --username Administrator \
+    --password password \
+    --set \
+    --audit-enabled 1
+
+echo "Waiting for startup completion"
+# Wait for startup - no great way for this
+until curl -u "Administrator:password" http://127.0.0.1:8091/pools/default &> /dev/null; do
+    echo "Not running, waiting to recheck"
+    sleep 2
+done
+
+echo "Running"
+
+# Create a bucket
+couchbase-cli bucket-create -c 127.0.0.1 \
+    --username Administrator \
+    --password password \
+    --bucket testBucket \
+    --bucket-type couchbase \
+    --bucket-ramsize 1024 \
+    --max-ttl 500000000 \
+    --durability-min-level persistToMajority \
+    --enable-flush 0
+
+echo "Bucket created"
+
+# Ensure everyone can read the logs as new ones are created
+until ! chmod -R a+r /opt/couchbase/var/lib/couchbase/logs/; do
+    sleep 10
+done
+
+echo "Exiting"

--- a/examples/containers/configure-cbs.sh
+++ b/examples/containers/configure-cbs.sh
@@ -35,12 +35,12 @@ couchbase-cli cluster-init -c 127.0.0.1 \
     --cluster-username Administrator \
     --cluster-password password \
     --services data,index,query,fts,analytics \
-    --cluster-ramsize 2048 \
-    --cluster-index-ramsize 1024 \
-    --cluster-eventing-ramsize 1024 \
-    --cluster-fts-ramsize 1024 \
+    --cluster-ramsize 1024 \
+    --cluster-index-ramsize 512 \
+    --cluster-eventing-ramsize 512 \
+    --cluster-fts-ramsize 512 \
     --cluster-analytics-ramsize 1024 \
-    --cluster-fts-ramsize 1024 \
+    --cluster-fts-ramsize 512 \
     --cluster-name "CMOS container test" \
     --index-storage-setting default
 

--- a/examples/containers/configure-cbs.sh
+++ b/examples/containers/configure-cbs.sh
@@ -21,6 +21,7 @@ rm -rf /opt/couchbase/var/lib/couchbase/logs/*
 mkdir -p /opt/couchbase/var/lib/couchbase/{config,data,stats,logs}
 
 echo "Run up Couchbase Server"
+# The actual command to run CB server based on the server image entrypoint.
 /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput &
 
 echo "Wait for it to be ready"

--- a/examples/containers/docker-compose-exporter.yml
+++ b/examples/containers/docker-compose-exporter.yml
@@ -1,0 +1,20 @@
+---
+# This is a simple compose stack to handle Couchbase Server 6 Prometheus monitoring using the exporter.
+version: '3'
+
+networks:
+    back:
+
+services:
+    # Exporter required for server <7
+    exporter:
+        container_name: exporter
+        image: couchbase/exporter:1.0.5
+        command:
+            - --couchbase-address=db1
+        ports:
+            - 9091:9091
+        depends_on:
+            - db1
+        networks:
+            - back

--- a/examples/containers/docker-compose-exporter.yml
+++ b/examples/containers/docker-compose-exporter.yml
@@ -1,5 +1,7 @@
 ---
 # This is a simple compose stack to handle Couchbase Server 6 Prometheus monitoring using the exporter.
+# It is intended to be run alongside the Couchbase Server stack with CMOS in this directory.
+# For example: docker-compose up -f docker-compose.yml -f docker-compose-exporter.yml
 version: '3'
 
 networks:

--- a/examples/containers/docker-compose.yml
+++ b/examples/containers/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     # This section is intended to represent a typical local deployment, instead of containers it could be done with native binaries
     db1:
         container_name: db1
-        image: ${SERVER_IMAGE}
+        image: ${COUCHBASE_SERVER_IMAGE}
         ports:
             - 8091-8096:8091-8096
             - 11210-11211:11210-11211
@@ -71,21 +71,10 @@ services:
         networks:
             - back
 
-    # Logging disabled if not using the custom entrypoint above.
-    # permission-fixer:
-    #     image: bash
-    #     # CB server forces this on us as the permissions for the rebalance directory as well as logs are not for all
-    #     # https://issues.couchbase.com/browse/MB-46485
-    #     command: sh -c "mkdir -p /opt/couchbase/var/lib/couchbase/logs/rebalance; while true; do sleep 30;chmod -R a+r /opt/couchbase/var/lib/couchbase/logs/; done"
-    #     user: root
-    #     volumes:
-    #         - log-volume:/opt/couchbase/var/lib/couchbase/logs/:rw
-
     logging:
         container_name: logging
         image: ${FLUENT_BIT_IMAGE}
         ports:
-            # Metrics
             - "2020:2020"
         depends_on:
             - db1
@@ -97,19 +86,6 @@ services:
             - log-volume:/opt/couchbase/var/lib/couchbase/logs/:ro
         networks:
             - back
-
-    # Exporter required for server <7
-    # exporter:
-    #     container_name: exporter
-    #     image: couchbase/exporter:1.0.5
-    #     command:
-    #         - --couchbase-address=db1
-    #     ports:
-    #         - 9091:9091
-    #     depends_on:
-    #         - db1
-    #     networks:
-    #         - back
 
 volumes:
     log-volume:

--- a/examples/containers/docker-compose.yml
+++ b/examples/containers/docker-compose.yml
@@ -13,17 +13,13 @@ networks:
 services:
 
     # This first section is the main thrust of the microlith, it runs the all-in-one container up
-    couchbase-grafana:
-        # Build using build kit so we can do ssh mounts for private repo, do not build here.
-        # Unfortunately Docker Compose does not use locally built images, it tries to pull them unless you specify 'build'
-        build:
-            context: ../../microlith/
-        # image: couchbase-observability:v1
-        container_name: couchbase-grafana
+    couchbase-cmos:
+        image: ${CMOS_IMAGE}
+        container_name: couchbase-cmos
         # Note an environment file can be used as well, this is likely better for production
         environment:
             # Disable various components as an example
-            - DISABLE_LOKI=true
+            # - DISABLE_LOKI=true
             # - DISABLE_JAEGER=true
             # Log to local files rather than stdout
             - ENABLE_LOG_TO_FILE=true
@@ -35,7 +31,8 @@ services:
             # This location stores any dynamic Prometheus info (e.g. targets to scrape)
             # Update as necessary and it should be automatically picked up at the next interval (30 seconds)
             # http://localhost:8080/prometheus/service-discovery
-            - ./dynamic/prometheus/couchbase-servers/:/etc/prometheus/couchbase/custom/:ro
+            # No longer required with new config service unless you want to detain and maintain.
+            # - ./dynamic/prometheus/couchbase-servers/:/etc/prometheus/couchbase/custom/:ro
             - ./dynamic/prometheus/custom-alertmanagers/:/etc/prometheus/alertmanager/custom/:ro
             # Custom alerts can be provided like so: http://localhost:8080/prometheus/rules#Custom
             - ./dynamic/prometheus/custom-alert-rules/:/etc/prometheus/alerting/custom/:ro
@@ -58,20 +55,23 @@ services:
             - 8080:8080
             # Cluster monitor
             - 7196:7196
+            # Loki
+            - 3100:3100
 
     # This section is intended to represent a typical local deployment, instead of containers it could be done with native binaries
     db1:
         container_name: db1
-        image: couchbase/server-sandbox:7.0.0
+        image: ${SERVER_IMAGE}
         ports:
             - 8091-8096:8091-8096
             - 11210-11211:11210-11211
         volumes:
+            - ./configure-cbs.sh:/entrypoint.sh
             - log-volume:/opt/couchbase/var/lib/couchbase/logs/:rw
         networks:
             - back
 
-    # Logging disabled
+    # Logging disabled if not using the custom entrypoint above.
     # permission-fixer:
     #     image: bash
     #     # CB server forces this on us as the permissions for the rebalance directory as well as logs are not for all
@@ -81,34 +81,35 @@ services:
     #     volumes:
     #         - log-volume:/opt/couchbase/var/lib/couchbase/logs/:rw
 
-    # logging:
-    #     container_name: logging
-    #     image: couchbase/fluent-bit:1.1.0
-    #     ports:
-    #         # Metrics
-    #         - "2020:2020"
-    #     depends_on:
-    #         - db1
-    #         - couchbase-grafana
-    #     environment:
-    #         - COUCHBASE_LOGS=/opt/couchbase/var/lib/couchbase/logs
-    #     volumes:
-    #         - log-volume:/opt/couchbase/var/lib/couchbase/logs/:ro
-    #         - ../../microlith/fluent-bit/fluent-bit.conf.server:/fluent-bit/config/fluent-bit.conf:ro
-    #     networks:
-    #         - back
-
-    exporter:
-        container_name: exporter
-        image: couchbase/exporter:1.0.5
-        command:
-            - --couchbase-address=db1
+    logging:
+        container_name: logging
+        image: ${FLUENT_BIT_IMAGE}
         ports:
-            - 9091:9091
+            # Metrics
+            - "2020:2020"
         depends_on:
             - db1
+            - couchbase-cmos
+        environment:
+            - LOKI_HOST=couchbase-cmos
+            - LOKI_MATCH=*
+        volumes:
+            - log-volume:/opt/couchbase/var/lib/couchbase/logs/:ro
         networks:
             - back
+
+    # Exporter required for server <7
+    # exporter:
+    #     container_name: exporter
+    #     image: couchbase/exporter:1.0.5
+    #     command:
+    #         - --couchbase-address=db1
+    #     ports:
+    #         - 9091:9091
+    #     depends_on:
+    #         - db1
+    #     networks:
+    #         - back
 
 volumes:
     log-volume:

--- a/examples/containers/run.sh
+++ b/examples/containers/run.sh
@@ -21,4 +21,6 @@ DOCKER_TAG=${DOCKER_TAG:-v1}
 CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
 
 rm -rf "${SCRIPT_DIR}"/logs/*.log
-docker-compose -f "${SCRIPT_DIR}"/docker-compose.yml up -d --force-recreate
+pushd "${SCRIPT_DIR}" || exit 1
+    docker-compose up -d --force-recreate
+popd || exit

--- a/examples/containers/run.sh
+++ b/examples/containers/run.sh
@@ -16,10 +16,6 @@ set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-DOCKER_USER=${DOCKER_USER:-couchbase}
-DOCKER_TAG=${DOCKER_TAG:-v1}
-CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
-
 rm -rf "${SCRIPT_DIR}"/logs/*.log
 pushd "${SCRIPT_DIR}" || exit 1
     docker-compose up -d --force-recreate

--- a/examples/containers/stop.sh
+++ b/examples/containers/stop.sh
@@ -16,4 +16,6 @@ set -u
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-docker-compose -f "${SCRIPT_DIR}"/docker-compose.yml down -v --remove-orphans
+pushd "${SCRIPT_DIR}" || exit 1
+    docker-compose down -v --remove-orphans
+popd || exit


### PR DESCRIPTION
Switched to using the official image although this will need an update for release.
Now sets up Couchbase Server using the generic entrypoint to ensure we have a bucket, etc. declaratively similar to what the server-sandbox image did but for any image.