### PR TITLE
CMOS-158: Always build CMOS container for examples until 0.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ container-clean:
 				  ${DOCKER_USER}/observability-stack-test-dist:${DOCKER_TAG} \
 				  ${DOCKER_USER}/observability-stack-docs-generator:${DOCKER_TAG} \
 				  ${DOCKER_USER}/observability-stack-config-service:${DOCKER_TAG}
-	docker image prune --force --volumes
+	docker image prune --force
 
 clean: container-clean
 	rm -rf $(ARTIFACTS) bin/ dist/ test-dist/ build/ .cache/ microlith/html/cmos/ microlith/docs/ microlith/config-svc/

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ all: clean build lint test-unit container container-oss container-lint container
 # We need to copy docs in for packaging: https://github.com/moby/moby/issues/1676
 # The other option is to tar things up and pass as the build context: tar -czh . | docker build -
 build:
+	rm -rf microlith/docs/
 	cp -R docs/ microlith/docs/
 	rm -rf microlith/config-svc/
 	cp -R config-svc microlith/config-svc/
@@ -134,7 +135,8 @@ container-clean:
 	docker image prune --force --volumes
 
 clean: container-clean
-	rm -rf $(ARTIFACTS) bin/ dist/ test-dist/ build/ .cache/ microlith/html/cmos/ microlith/docs/
+	rm -rf $(ARTIFACTS) bin/ dist/ test-dist/ build/ .cache/ microlith/html/cmos/ microlith/docs/ microlith/config-svc/
+	rm -f microlith/git-commit.txt
 	-examples/containers/stop.sh
 	rm -f examples/containers/logs/*.log
 	-examples/kubernetes/stop.sh

--- a/examples/containers/.env
+++ b/examples/containers/.env
@@ -1,3 +1,3 @@
 COUCHBASE_SERVER_IMAGE=couchbase/server:7.0.2
 FLUENT_BIT_IMAGE=couchbase/fluent-bit:1.1.2
-CMOS_IMAGE=registry.gitlab.com/cb-vanilla/observability-stack:latest
+CMOS_IMAGE=couchbase/observability-stack:v1

--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -1,4 +1,4 @@
-An example of using the microlith image locally.
+An example of using the microlith image locally and CMOS is then available via http://localhost:8080.
 
 To run a full stack use the `Makefile` at the top of this repo and just execute the target: `make example-containers`
 
@@ -8,3 +8,5 @@ The `Add Cluster` page can be used to add the `db1` host with default credential
 Add additional clusters by running up a new Couchbase Server image and either attaching it to an existing cluster or creating a new one.
 
 It demonstrates how to mount in custom rules and end points to scrape.
+
+Make sure nothing else is using port 8080 already locally.

--- a/examples/containers/run.sh
+++ b/examples/containers/run.sh
@@ -16,6 +16,15 @@ set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+COUCHBASE_SERVER_IMAGE=${COUCHBASE_SERVER_IMAGE:-couchbase/server:7.0.2}
+
+DOCKER_USER=${DOCKER_USER:-couchbase}
+DOCKER_TAG=${DOCKER_TAG:-v1}
+CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
+
+# Ensure we built the container locally first
+make -C "${SCRIPT_DIR}/../.." container
+
 rm -rf "${SCRIPT_DIR}"/logs/*.log
 pushd "${SCRIPT_DIR}" || exit 1
     docker-compose up -d --force-recreate

--- a/tools/build-oss-container.sh
+++ b/tools/build-oss-container.sh
@@ -22,6 +22,9 @@ DOCKER_USER=${DOCKER_USER:-couchbase}
 DOCKER_TAG=${DOCKER_TAG:-v1}
 CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
 
+# Set up source directory appropriately first always
+make -C "${SCRIPT_DIR}/.." build
+
 # Remove everything between `# Couchbase proprietary start` and `# Couchbase proprietary end`
 sed '/^# Couchbase proprietary start/,/^# Couchbase proprietary end/d' "$SCRIPT_DIR/../microlith/Dockerfile" > "$SCRIPT_DIR/../microlith/Dockerfile.oss"
 echo "Building OSS image: $CMOS_IMAGE"


### PR DESCRIPTION
Resolves: https://issues.couchbase.com/browse/CMOS-158

Switch to always building the images for now, once we have a released version that is what the examples should default to with instructions for developers to build locally or a separate compose stack.