### PR TITLE
CMOS-158: Update example docs

### DIFF
--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -10,3 +10,5 @@ Add additional clusters by running up a new Couchbase Server image and either at
 It demonstrates how to mount in custom rules and end points to scrape.
 
 Make sure nothing else is using port 8080 already locally.
+
+Make sure to build the CMOS container before using the local [`run.sh`](./run.sh) script via a call to `make container` or `make container-oss` as appropriate.

--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -1,6 +1,6 @@
 An example of using the microlith image locally and CMOS is then available via http://localhost:8080.
 
-To run a full stack use the `Makefile` at the top of this repo and just execute the target: `make example-containers`
+To run a full stack use the `Makefile` at the top of this repo and just execute the target: `make example-containers`.
 
 This will spin up a Couchbase cluster (single node) and CMOS.
 The `Add Cluster` page can be used to add the `db1` host with default credentials of `Administrator:password`.

--- a/examples/containers/run.sh
+++ b/examples/containers/run.sh
@@ -22,8 +22,12 @@ DOCKER_USER=${DOCKER_USER:-couchbase}
 DOCKER_TAG=${DOCKER_TAG:-v1}
 CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
 
-# Ensure we built the container locally first
-make -C "${SCRIPT_DIR}/../.." container
+# Ensure we build the container locally first otherwise make
+# sure one is tagged as above CMOS_IMAGE for use in the .env file.
+if [[ "${SKIP_CONTAINER_BUILD:-yes}" != "yes" ]]; then
+    echo "Building CMOS container"
+    make -C "${SCRIPT_DIR}/../.." container
+fi
 
 rm -rf "${SCRIPT_DIR}"/logs/*.log
 pushd "${SCRIPT_DIR}" || exit 1

--- a/examples/containers/run.sh
+++ b/examples/containers/run.sh
@@ -20,14 +20,9 @@ COUCHBASE_SERVER_IMAGE=${COUCHBASE_SERVER_IMAGE:-couchbase/server:7.0.2}
 
 DOCKER_USER=${DOCKER_USER:-couchbase}
 DOCKER_TAG=${DOCKER_TAG:-v1}
-CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
-
 # Ensure we build the container locally first otherwise make
 # sure one is tagged as above CMOS_IMAGE for use in the .env file.
-if [[ "${SKIP_CONTAINER_BUILD:-yes}" != "yes" ]]; then
-    echo "Building CMOS container"
-    make -C "${SCRIPT_DIR}/../.." container
-fi
+CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
 
 rm -rf "${SCRIPT_DIR}"/logs/*.log
 pushd "${SCRIPT_DIR}" || exit 1

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,4 +2,6 @@ This example runs up a local KIND cluster (3 worker nodes), deploys Couchbase to
 
 An ingress is created to allow you to access it all via http://localhost/
 
+To run a full stack use the `Makefile` at the top of this repo and just execute the target: `make example-kubernetes`.
+
 Make sure to build the CMOS container before using the local [`run.sh`](./run.sh) script via a call to `make container` or `make container-oss` as appropriate.

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,3 +1,5 @@
 This example runs up a local KIND cluster (3 worker nodes), deploys Couchbase to it using the CAO and then runs up our monitoring stack.
 
 An ingress is created to allow you to access it all via http://localhost/
+
+Make sure to build the CMOS container before using the local [`run.sh`](./run.sh) script via a call to `make container` or `make container-oss` as appropriate.

--- a/examples/kubernetes/run.sh
+++ b/examples/kubernetes/run.sh
@@ -23,6 +23,13 @@ DOCKER_USER=${DOCKER_USER:-couchbase}
 DOCKER_TAG=${DOCKER_TAG:-v1}
 CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
 
+# Ensure we build the container locally first otherwise make
+# sure one is tagged as above CMOS_IMAGE for use in the config.
+if [[ "${SKIP_CONTAINER_BUILD:-yes}" != "yes" ]]; then
+    echo "Building CMOS container"
+    make -C "${SCRIPT_DIR}/../.." container
+fi
+
 if [[ "${SKIP_CLUSTER_CREATION:-no}" != "yes" ]]; then
   echo "Recreating full cluster"
 

--- a/examples/kubernetes/run.sh
+++ b/examples/kubernetes/run.sh
@@ -21,14 +21,9 @@ COUCHBASE_SERVER_IMAGE=${COUCHBASE_SERVER_IMAGE:-couchbase/server:7.0.2}
 
 DOCKER_USER=${DOCKER_USER:-couchbase}
 DOCKER_TAG=${DOCKER_TAG:-v1}
-CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
-
 # Ensure we build the container locally first otherwise make
 # sure one is tagged as above CMOS_IMAGE for use in the config.
-if [[ "${SKIP_CONTAINER_BUILD:-yes}" != "yes" ]]; then
-    echo "Building CMOS container"
-    make -C "${SCRIPT_DIR}/../.." container
-fi
+CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
 
 if [[ "${SKIP_CLUSTER_CREATION:-no}" != "yes" ]]; then
   echo "Recreating full cluster"


### PR DESCRIPTION
Add optional container build to the `run.sh` script.
The `Makefile` target does run the `container` target first though anyway.