### PR TITLE
Fix incorrect reference to `secure` as opposed to `useTLS`

### DIFF
--- a/microlith/html/promwebform.html
+++ b/microlith/html/promwebform.html
@@ -223,7 +223,7 @@
                         username: this.serverUsername,
                         password: this.serverPassword,
                         managementPort: parseInt(this.managementPort, 10),
-                        secure: this.secure,
+                        useTLS: this.useTLS,
                       },
                     }),
                   })


### PR DESCRIPTION
As part of code review for https://github.com/couchbaselabs/observability/pull/79, I changed the variable `secure` to `useTLS`, but missed some places: this fixes the last remaining one. This wasn't caught because we don't test the form with TLS-enabled clusters - perhaps we should.