### PR TITLE
CMOS-163: Resolve issue with Ingress and make optional

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,7 +2,8 @@ This example runs up a local KIND cluster (3 worker nodes), deploys Couchbase to
 
 By default, it gives you the command to handle port-forwarding to the CMOS service on http://localhost:8080/.
 
-An ingress is optionally created (`SKIP_INGRESS=no`) to allow you to access it all via http://localhost/ but this can trigger forwarding issues in some of the CMOS documentation.
+An ingress can be optionally created (set `SKIP_INGRESS=no`) to allow you to access it all via http://localhost/ but this can trigger forwarding issues in some of the CMOS documentation.
+This is not created by default though to also allow multiple local clusters.
 
 To run a full stack use the `Makefile` at the top of this repo and just execute the target: `make example-kubernetes`.
 

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,7 +1,11 @@
 This example runs up a local KIND cluster (3 worker nodes), deploys Couchbase to it using the CAO and then runs up our monitoring stack.
 
-An ingress is created to allow you to access it all via http://localhost/
+By default, it gives you the command to handle port-forwarding to the CMOS service on http://localhost:8080/.
+
+An ingress is optionally created (`SKIP_INGRESS=no`) to allow you to access it all via http://localhost/ but this can trigger forwarding issues in some of the CMOS documentation.
 
 To run a full stack use the `Makefile` at the top of this repo and just execute the target: `make example-kubernetes`.
 
 Make sure to build the CMOS container before using the local [`run.sh`](./run.sh) script via a call to `make container` or `make container-oss` as appropriate.
+
+Once you have it running, use the CMOS `Add Cluster` page to add any clusters to monitor but ensure the `Add to Prometheus` option is disabled as we use `kubernetes_sd_config` to auto-discover pods to monitor.

--- a/examples/kubernetes/custom-values.yaml
+++ b/examples/kubernetes/custom-values.yaml
@@ -9,11 +9,11 @@ cluster:
         prometheus:
             enabled: false # We're using server 7 metrics directly
     security:
-        # To simplify for scraping we hardcode the passwords.
+        # To simplify for scraping we hardcode the credentials.
         # They should be auto-generated really and the Secret value
         # used by mounting into CMOS (or getting it to retrieve during
         # startup).
-        username: admin
+        username: Administrator
         password: password
     servers:
         # We use custom annotations to forward to CMOS Loki


### PR DESCRIPTION
Resolves https://issues.couchbase.com/browse/CMOS-163 due to slight race condition between marking pods as ready and traffic reaching them correctly. Simple solution is best so just retry. Also updated to follow the slight changes in the official Kind ingress documentation as well: https://kind.sigs.k8s.io/docs/user/ingress/

Modified slightly to also make the ingress optional per some of the documentation discussions but also as a few of the links for the tooling do not function correctly with it. This also means we can run multiple isolated clusters as well.