### PR TITLE
Allow conditional docs contents for the packaged environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,6 @@ Ensure that the documnetation looks correct when viewed via the landing page.
 If there are certain aspects of the documentation that are only relevant when packaged inside the container, use `ifdef::env-packaged[]` to delimit these.
 For example:
 
-[pass]
 ```asciidoc
 ifdef::env-packaged[]
 This text will only appear inside the container. It will not appear on docs.couchbase.com.
@@ -177,7 +176,6 @@ endif::env-packaged[]
 Similarly, you can use `ifndef` to hide certain content when inside the container.
 For example:
 
-[pass]
 ```asciidoc
 ifndef::env-packaged[]
 This text will only appear on docs.couchbase.com and on GitHub. It will not appear inside the container.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,26 @@ Ensure that the documentation looks correct when present in Github.
 
 Ensure that the documnetation looks correct when viewed via the landing page.
 
+If there are certain aspects of the documentation that are only relevant when packaged inside the container, use `ifdef::env-packaged[]` to delimit these.
+For example:
+
+[pass]
+```asciidoc
+ifdef::env-packaged[]
+This text will only appear inside the container. It will not appear on docs.couchbase.com.
+endif::env-packaged[]
+```
+
+Similarly, you can use `ifndef` to hide certain content when inside the container.
+For example:
+
+[pass]
+```asciidoc
+ifndef::env-packaged[]
+This text will only appear on docs.couchbase.com and on GitHub. It will not appear inside the container.
+endif::env-packaged[]
+```
+
 ### Site Layout
 
 Important things about this repository:

--- a/docs/antora-container-playbook.yml
+++ b/docs/antora-container-playbook.yml
@@ -10,3 +10,6 @@ content:
 ui:
     bundle:
         url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
+asciidoc:
+    attributes:
+        env-packaged: ''

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,16 +1,20 @@
 * xref:index.adoc[Home]
 * xref:quickstart.adoc[Quick start guide]
 
+ifdef::env-packaged[]
+
 .Configuration
-* link:http://localhost:8080/promwebform.html[Add Cluster^]
-* link:http://localhost:8080/prometheus/alerts/[Prometheus Alerts^]
-* link:http://localhost:8080/prometheus/rules/[Prometheus Rules^]
-* link:http://localhost:8080/prometheus/targets/[Prometheus Targets^]
+* link:/promwebform.html[Add Cluster^]
+* link:/prometheus/alerts/[Prometheus Alerts^]
+* link:/prometheus/rules/[Prometheus Rules^]
+* link:/prometheus/targets/[Prometheus Targets^]
 
 .Tooling
-* link:http://localhost:8080/alertmanager/[Alert Manager^]
-* link:http://localhost:8080/grafana/[Grafana^]
-* link:http://localhost:8080/prometheus/[Prometheus^]
+* link:/alertmanager/[Alert Manager^]
+* link:/grafana/[Grafana^]
+* link:/prometheus/[Prometheus^]
+
+endif::env-packaged[]
 
 .Architecture
 * xref:architecture.adoc[Architecture overview]

--- a/docs/modules/ROOT/pages/support.adoc
+++ b/docs/modules/ROOT/pages/support.adoc
@@ -12,7 +12,8 @@ This can be disabled by setting the environment variable `LOG_TO_STDOUT` to `fal
 
 === Collecting Information
 
-Use the link:/collect-info.html[Collect Information] form to create a tar-ball of all CMOS logs and configuration.
+ifdef::env-packaged[Use the link:/collect-info.html[Collect Information] form to create a tar-ball of all CMOS logs and configuration.]
+ifndef::env-packaged[If the CMOS web server is enabled, visit `/collect-info.html` to create a tar-ball of all CMOS logs and configuration.]
 If you cannot access the web server or it is disabled, the same can be done by running `/collect-information.sh` in the container.
 The output will be saved to `/tmp/support` in the container.
 If the web server is enabled, it can also be accessed on `/support`.


### PR DESCRIPTION
Some parts of the docs only make sense when packaged inside the container, while others only make sense outside it. This commit introduces the `env-packaged` attribute, which can be used in an AsciiDoc `ifdef` to have conditional content.

For example, when built inside the container, the Support page links directly to the collect info form, while when built outside it instead has the URL of the form.