### PR TITLE
Fix k8s test failure after CMOS-168 changes

### DIFF
--- a/testing/bats/integration/kubernetes/standalone.bats
+++ b/testing/bats/integration/kubernetes/standalone.bats
@@ -222,7 +222,7 @@ __EOF__
     # shellcheck disable=SC2046
     run kubectl logs --namespace="$TEST_NAMESPACE" $(kubectl get pods --namespace="$TEST_NAMESPACE" -o=name|grep couchbase-grafana)
     assert_success
-    assert_output --partial "[ENTRYPOINT] Disabled as DISABLE_LOKI set"
+    assert_output --partial "Disabled as DISABLE_LOKI set"
 
     # Port forward into the K8S cluster
     local pid_file

--- a/testing/helpers/test-helpers.bash
+++ b/testing/helpers/test-helpers.bash
@@ -42,7 +42,7 @@ function ensure_variables_set() {
     fi
 }
 
-# Finds a random, unused port on the system and echos it to the given variable.
+# Finds a random, unused port on the system and echos it.
 # Returns 1 and echos -1 if it can't find one.
 # Have to do it this way to prevent variable shadowing.
 function find_unused_port() {


### PR DESCRIPTION
We changed the logging format which the tests depended on. Update the tests to match.

Tested on https://github.com/couchbaselabs/observability/actions/runs/1480417033 - native tests are still running but k8s has already passed:

```
ok 4 Verify disabling of components in microlith in 101054ms
```