### PR TITLE
CMOS-179: Disable Promtail by default as a workaround for crash issues

### DIFF
--- a/microlith/run.sh
+++ b/microlith/run.sh
@@ -71,6 +71,12 @@ export CMOS_LOGS_ROOT=${CMOS_LOGS_ROOT:-/logs}
 
 export PROMTAIL_CONFIG_FILE=${PROMTAIL_CONFIG_FILE:-/etc/promtail/config-microlith.yaml}
 export PROMTAIL_HTTP_PORT=${PROMTAIL_HTTP_PORT:-9080}
+# Temporary, see https://issues.couchbase.com/browse/CMOS-179
+if [ "${DISABLE_PROMTAIL:-true}" == "false" ]; then
+  unset DISABLE_PROMTAIL
+else
+  DISABLE_PROMTAIL=true
+fi
 
 # Clean up dynamic targets generated
 export PROMETHEUS_DYNAMIC_INTERNAL_DIR=${PROMETHEUS_DYNAMIC_INTERNAL_DIR:-/etc/prometheus/couchbase/monitoring/}

--- a/testing/bats/smoke/prometheus-metrics.bats
+++ b/testing/bats/smoke/prometheus-metrics.bats
@@ -143,6 +143,7 @@ function metricGreaterThanZero() {
 }
 
 @test "verify logs are being ingested by Promtail and Loki" {
+    skip "CMOS-179"
     # Are we ready?
     wait_for_url 10 "$CMOS_HOST/prometheus/-/ready"
 


### PR DESCRIPTION
In some cases we have seen Promtail crash immediately upon startup - see CMOS-179 for details. This appears to be either machine-specific, or related to some configuration.

Disable Promtail by default as a workaround. We don't actually have any dashboards that make use of Promtail's logging, so we don't lose anything.

I'll convert CMOS-179 into a tracking issue for re-enabling it.