### PR TITLE
Remove prune from multi/stop.sh, Fix anonymous volumes not being removed

### DIFF
--- a/examples/containers/multi/helpers/driver.sh
+++ b/examples/containers/multi/helpers/driver.sh
@@ -31,7 +31,7 @@ function start_new_nodes() {
 
     local i=0
     for ((i; i<num_nodes; i++)); do
-        docker run -d --rm --name "node$i" --hostname="node$i.local" --network=multi_shared_network \
+        docker run -d --name "node$i" --hostname="node$i.local" --network=multi_shared_network \
         -p $((8091+i)):8091 "cbs_server_exp" > /dev/null
         nodes_ready+=(false)
     done

--- a/examples/containers/multi/stop.sh
+++ b/examples/containers/multi/stop.sh
@@ -28,19 +28,20 @@ CMOS_IMAGE=${CMOS_IMAGE:-$DOCKER_USER/observability-stack:$DOCKER_TAG}
 export CMOS_IMAGE # This is required for reference in the docker-compose file
 
 # Delete ALL containers with the cbs_server_exp image
-docker ps -a --filter "ancestor=cbs_server_exp" --format '{{.ID }}' | xargs docker rm -f > /dev/null
+docker ps -a --filter "ancestor=cbs_server_exp" --format '{{.ID }}' | xargs docker rm -fv > /dev/null
 echo "All cbs_server_exp containers deleted successfully."
 
 # Delete the cbs_server_exp image - this needs to be here as we are using the CLI and so have no
 # reference to containers to be able to stop them without the image name. container-clean removes the 
 # tag. By moving to docker-compose for nodes this will be avoided.
-docker rmi "cbs_server_exp" -f && docker image prune --force
+docker rmi -f "cbs_server_exp"
 echo "cbs_server_exp image deleted."
 
 # Remove the CMOS container
 pushd "${SCRIPT_DIR}" || exit 1
     docker-compose down -v --remove-orphans
 popd || exit
+
 echo "------------------------------------"
 echo "Example stopped and cleaned successfully."
 


### PR DESCRIPTION
- For some reason Docker would not remove anonymous created by containers run with the --rm arg when said containers stop, as should happen.

This is an alternative (working) method.