### PR TITLE
CMOS-212: Upgrade Grafana to 8.2.7

### DIFF
--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:8.2.5 as grafana-official
+FROM grafana/grafana:8.2.7 as grafana-official
 FROM grafana/loki:2.4.1 as loki-official
 FROM prom/prometheus:v2.31.0 as prometheus-official
 FROM prom/alertmanager:v0.23.0 as alertmanager-official


### PR DESCRIPTION
We should probably pull in 8.3.x at some point soon, but for now upgrade to 8.2.7 as it's less risky.

Gave it a local build as a sanity check, everything appears to work, and the changelog between 8.2.5 and 8.2.7 is relatively short:

```
8.2.7 (2021-12-07)
Security: Fixes CVE-2021-43798. For more information, see our blog
8.2.6 (2021-12-02)
Features and enhancements
Security: Upgrade Docker base image to Alpine 3.14.3. #42061, @dsotirakis
Security: Upgrade Go to 1.17.2. #42427, @idafurjes
Bug fixes
TimeSeries: Fix fillBelowTo wrongly affecting fills of unrelated series. #41998, @leeoniya
```
