### PR TITLE
Configure Dependabot to automatically check for updates to Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       directory: /
       schedule:
           interval: daily
+  - package-ecosystem: "docker"
+    directory: "/microlith"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
The configuration syntax should be correct (cf. https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#about-the-dependabotyml-file), but as far as I can tell there's no way to test it apart from seeing if it works