### PR TITLE
Upgrade couchbase/fluent-bit to 1.1.3

### DIFF
--- a/docs/modules/ROOT/pages/deployment-fluentbit.adoc
+++ b/docs/modules/ROOT/pages/deployment-fluentbit.adoc
@@ -54,7 +54,7 @@ An link:https://github.com/couchbase/couchbase-fluent-bit/tree/main/tools/loki-s
 
 [source,console]
 ----
-$ docker run --rm -d --name logger -v /opt/couchbase/var/lib/couchbase/logs/:/opt/couchbase/var/lib/couchbase/logs/:ro -e COUCHBASE_LOGS=/opt/couchbase/var/lib/couchbase/logs/ -e LOKI_MATCH="*" -e LOKI_HOST="127.0.0.1" couchbase/fluent-bit:1.1.2
+$ docker run --rm -d --name logger -v /opt/couchbase/var/lib/couchbase/logs/:/opt/couchbase/var/lib/couchbase/logs/:ro -e COUCHBASE_LOGS=/opt/couchbase/var/lib/couchbase/logs/ -e LOKI_MATCH="*" -e LOKI_HOST="127.0.0.1" couchbase/fluent-bit:1.1.3
 ----
 
 Replace `LOKI_HOST` here with your actual DNS name or IP address for CMOS.

--- a/docs/modules/ROOT/pages/tutorial-kubernetes.adoc
+++ b/docs/modules/ROOT/pages/tutorial-kubernetes.adoc
@@ -236,7 +236,7 @@ cluster:
         server:
             enabled: true
             sidecar:
-                image: couchbase/fluent-bit:1.1.2
+                image: couchbase/fluent-bit:1.1.3
     monitoring:
         prometheus:
             enabled: false # We're using server 7 metrics directly

--- a/examples/containers/.env
+++ b/examples/containers/.env
@@ -1,3 +1,3 @@
 COUCHBASE_SERVER_IMAGE=couchbase/server:7.0.2
-FLUENT_BIT_IMAGE=couchbase/fluent-bit:1.1.2
+FLUENT_BIT_IMAGE=couchbase/fluent-bit:1.1.3
 CMOS_IMAGE=couchbase/observability-stack:v1

--- a/examples/kubernetes/custom-values.yaml
+++ b/examples/kubernetes/custom-values.yaml
@@ -4,7 +4,7 @@ cluster:
         server:
             enabled: true
             sidecar:
-                image: couchbase/fluent-bit:1.1.2
+                image: couchbase/fluent-bit:1.1.3
     monitoring:
         prometheus:
             enabled: false # We're using server 7 metrics directly


### PR DESCRIPTION
This fixes an issue with incorrectly set couchbase.cluster labels from k8s, which would be nice to have in alerting rules.

Release notes: https://github.com/couchbase/couchbase-fluent-bit/releases/tag/1.1.3