### PR TITLE
CMOS-249: More Loki fixups

### DIFF
--- a/microlith/Dockerfile
+++ b/microlith/Dockerfile
@@ -341,9 +341,9 @@ RUN chown -R couchbase:couchbase /etc/prometheus /prometheus && \
     mkdir -p /logs && chmod 777 /logs && \
     mkdir -p /etc/prometheus/couchbase/monitoring/ && chmod 777 /etc/prometheus/couchbase/monitoring/ && \
     mkdir -p /etc/prometheus/couchbase/custom && \
-    mkdir -p /etc/cmos /tmp/support && \
+    mkdir -p /etc/cmos /tmp/support /tmp/loki/scratch && \
     chown -R couchbase:couchbase /entrypoints /logs /etc/prometheus/couchbase/ && \
-    chown -R couchbase:couchbase /data /priv /ui /etc/cmos /tmp/support
+    chown -R couchbase:couchbase /data /priv /ui /etc/cmos /tmp/support /tmp/loki
 
 # Location of dynamic target information for Prometheus
 ENV PROMETHEUS_DYNAMIC_INTERNAL_DIR=/etc/prometheus/couchbase/monitoring/

--- a/microlith/Dockerfile.rhel
+++ b/microlith/Dockerfile.rhel
@@ -262,8 +262,9 @@ RUN chown -R couchbase:couchbase /etc/prometheus /prometheus && \
     mkdir -p /logs && chmod 777 /logs && \
     mkdir -p /etc/prometheus/couchbase/monitoring/ && chmod 777 /etc/prometheus/couchbase/monitoring/ && \
     mkdir -p /etc/prometheus/couchbase/custom && \
+    mkdir -p /etc/cmos /tmp/support /tmp/loki/scratch && \
     chown -R couchbase:couchbase /entrypoints /logs /etc/prometheus/couchbase/ && \
-    chown -R couchbase:couchbase /data /priv /ui
+    chown -R couchbase:couchbase /data /priv /ui /etc/cmos /tmp/support /tmp/loki
 
 # Location of dynamic target information for Prometheus
 ENV PROMETHEUS_DYNAMIC_INTERNAL_DIR=/etc/prometheus/couchbase/monitoring/


### PR DESCRIPTION
Ensure it has the directories it expects on startup, otherwise it won't execute the rules