### PR TITLE
CMOS-250: Add smoke test for Loki alerts

### DIFF
--- a/microlith/entrypoints/loki.sh
+++ b/microlith/entrypoints/loki.sh
@@ -38,4 +38,4 @@ __EOF__
 mkdir -p /etc/loki/rules/fake
 /etc/loki/scripts/loki_alerts_prepare.sh
 
-/usr/bin/loki -config.file="${LOKI_CONFIG_FILE}"
+/usr/bin/loki -config.file="${LOKI_CONFIG_FILE}" -config.expand-env=true

--- a/microlith/loki/alerting/couchbase/test-rules.yaml
+++ b/microlith/loki/alerting/couchbase/test-rules.yaml
@@ -9,4 +9,4 @@ groups:
         expr: count_over_time({job="cmos-testing"}[1m]) > 0
         for: 0m
         labels:
-            job: couchbase-fluentbit
+          job: couchbase-fluentbit

--- a/microlith/loki/alerting/couchbase/test-rules.yaml
+++ b/microlith/loki/alerting/couchbase/test-rules.yaml
@@ -1,0 +1,12 @@
+---
+# This file contains rules only used for testing.
+# It will not be present in production unless the environment variable LOKI_ALERTS_INCLUDE_TEST is set to 'true'.
+groups:
+  - name: cmos-testing
+    rules:
+
+      - alert: SmokeTest
+        expr: count_over_time({job="cmos-testing"}[1m]) > 0
+        for: 0m
+        labels:
+            job: couchbase-fluentbit

--- a/microlith/loki/config.yml
+++ b/microlith/loki/config.yml
@@ -29,6 +29,9 @@ schema_config:
 ruler:
   alertmanager_url: http://localhost:9093/alertmanager
   enable_alertmanager_v2: true
+  # These two are overridden in tests - the default values should track the defaults in https://grafana.com/docs/loki/latest/configuration/#ruler_config
+  evaluation_interval: ${LOKI_RULER_EVALUATION_INTERVAL:1m}
+  resend_delay: ${LOKI_RULER_RESEND_DELAY:1m}
   rule_path: /tmp/loki/scratch
   storage:
     type: local

--- a/microlith/loki/scripts/loki_alerts_prepare.sh
+++ b/microlith/loki/scripts/loki_alerts_prepare.sh
@@ -23,6 +23,10 @@ fi
 
 set -e
 
+if [ "${LOKI_ALERTS_INCLUDE_TEST:-}" != 'true' ]; then
+  rm /etc/loki/alerting/couchbase/test-rules.yaml || true
+fi
+
 # Work on the rules, we substitute in-place to keep it simple
 while IFS= read -r -d '' FILE
 do
@@ -46,4 +50,3 @@ done < <(find "/etc/loki/alerting/" -type f \( -name '*.yaml' -o -name '*.yml' \
 mkdir -p /etc/loki/rules/fake
 shopt -s nullglob
 cp /etc/loki/alerting/couchbase/*.yaml /etc/loki/alerting/custom/*.yaml /etc/loki/rules/fake/
-

--- a/microlith/nginx/nginx.conf
+++ b/microlith/nginx/nginx.conf
@@ -39,6 +39,10 @@ http {
             proxy_pass  http://localhost:9093;
         }
 
+        location /loki/ {
+            proxy_pass  http://localhost:3100;
+        }
+
         # Self-monitoring
         location /_meta/status {
             stub_status;

--- a/testing/bats/smoke/loki-sanity-check.bats
+++ b/testing/bats/smoke/loki-sanity-check.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load "$HELPERS_ROOT/test-helpers.bash"
+load "$HELPERS_ROOT/url-helpers.bash"
+
+ensure_variables_set CMOS_HOST BATS_SUPPORT_ROOT BATS_ASSERT_ROOT
+
+load "$BATS_SUPPORT_ROOT/load.bash"
+load "$BATS_ASSERT_ROOT/load.bash"
+
+@test "Loki alerting rules operational" {
+    # Wait for Loki to come up, write a line to it, then ping Alertmanager until the alert shows up
+    # Can't use /ready because the reverse proxy will mangle the path to /loki/ready
+    wait_for_url 10 "$CMOS_HOST/loki/api/v1/status/buildinfo"
+    wait_for_url 10 "$CMOS_HOST/alertmanager/-/ready"
+
+    run curl -X POST -H "Content-Type: application/json" "$CMOS_HOST/loki/api/v1/push" --data @- <<EOF
+{
+    "streams": [
+        {
+            "stream": {
+                "job": "cmos-testing"
+            },
+            "values": [
+                ["$(date +%s)000000000", "test"]
+            ]
+        }
+    ]
+}
+EOF
+    assert_success
+
+    attempt=0
+    while true; do
+        run curl -o "$BATS_TEST_TMPDIR/alerts.json" "$CMOS_HOST/alertmanager/api/v2/alerts"
+        assert_success
+
+        run jq -c '.[] | select(.labels.alertname == "SmokeTest")' "$BATS_TEST_TMPDIR/alerts.json"
+        assert_success
+        if [[ "$output" == "" ]]; then
+            if [ "$attempt" -lt 30 ]; then
+                attempt=$(( attempt + 1 ))
+                sleep 5
+            else
+                fail "Didn't find the smoke test alert even after $attempt attempts"
+            fi
+        else
+            break
+        fi
+    done
+}

--- a/testing/helpers/test-helpers.bash
+++ b/testing/helpers/test-helpers.bash
@@ -100,7 +100,7 @@ function capture_cmosinfo() {
 # Exposes a variable $CMOS_HOST with the nginx host:port.
 # All parameters will be passed on to docker before the image.
 function _start_cmos() {
-    docker run --rm -d -p '8080' --name cmos "$@" "$CMOS_IMAGE"
+    docker run --rm -d -p '8080' --name cmos -e 'LOKI_RULER_RESEND_DELAY=5s' -e 'LOKI_RULER_EVALUATION_INTERVAL=5s' -e 'LOKI_ALERTS_INCLUDE_TEST=true' "$@" "$CMOS_IMAGE"
 
     local cmos_port
     cmos_port=$(docker inspect cmos -f '{{with index .NetworkSettings.Ports "8080/tcp"}}{{ with index . 0 }}{{ .HostPort }}{{end}}{{end}}')


### PR DESCRIPTION
Add a test case that checks if Loki is properly evaluating alerting rules and sending alerts to Alertmanager. This should hopefully ensure a situation like CMOS-249 cannot happen again.

There's some test-specific configuration in the Loki config file - this is solely to ensure tests don't take too long. The testing rules file is deleted by loki_alerts_prepare.sh unless explicitly told not to, so the impact in production should be minimal.