### PR TITLE
CMOS-250: Add unit tests for Loki rules

### DIFF
--- a/.github/workflows/pr-loki.yml
+++ b/.github/workflows/pr-loki.yml
@@ -10,23 +10,18 @@ on:
             - microlith/loki/alerting/**
             - testing/loki_alerts/**
 
-    workflow_dispatch:
-        inputs:
-            ref:
-                description: Branch, tag, or commit SHA to run against
-                required: false
-                default: main
-
 jobs:
     unit-tests:
         name: Unit test Loki rules
         runs-on: ubuntu-20.04
         timeout-minutes: 15
         steps:
+            - run: |
+                echo "ref: ${{ github.event.inputs.ref }}"
+                echo "user: ${{ github.event.inputs.user }}"
+
             - name: Checkout code
               uses: actions/checkout@v2
-              with:
-                ref: ${{ github.event.inputs.ref || 'main' }}
             
             - name: Run tests
               run: make test-loki-rules

--- a/.github/workflows/pr-loki.yml
+++ b/.github/workflows/pr-loki.yml
@@ -1,0 +1,32 @@
+---
+name: PR - Loki rule tests
+# Validate our Loki alerting rules
+
+on:
+    pull_request:
+        branches:
+            - main
+        paths:
+            - microlith/loki/alerting/**
+            - testing/loki_alerts/**
+
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: Branch, tag, or commit SHA to run against
+                required: false
+                default: main
+
+jobs:
+    unit-tests:
+        name: Unit test Loki rules
+        runs-on: ubuntu-20.04
+        timeout-minutes: 15
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                ref: ${{ github.event.inputs.ref || 'main' }}
+            
+            - name: Run tests
+              run: make test-loki-rules

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,7 @@ testing/diagnostics/
 testing/.vagrant
 testing/bats/integration/kubernetes/resources/default-microlith.yaml
 testing/bats/integration/kubernetes/resources/helm/couchbase-cluster-logging-values.yaml
+testing/loki_alerts/fluent-bit.conf
 .DS_Store
 *.log
+!testing/loki_alerts/*/*/*.log

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ config-svc-test-unit:
 config-svc-lint:
 	docker run --rm -i -v  ${PWD}/config-svc:/app -w /app golangci/golangci-lint:v1.42.1 golangci-lint run -v
 
+test-loki-rules:
+	testing/loki_alerts/run_all.sh
+
 # NOTE: This target is only for local development.
 container: CBMULTIMANAGER_REF ?= master
 container: build

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -44,7 +44,7 @@ groups:
         expr: |
           sum(count_over_time(
             {file="memcached.log"} |= `Invalid format specified for "DCP_OPEN"` |= `Reason:"Key length exceeds 250"` | json hostname="hostname" [5m]
-          )) by (couchbase_cluster, hostname) > 0
+          )) by (cluster, hostname) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -52,9 +52,9 @@ groups:
           severity: critical
           health_check_id: CB90033
           health_check_name: longDcpNames
-          cluster: '{{ $labels.couchbase_cluster }}'
+          cluster: '{{ $labels.cluster }}'
         annotations:
-          title: DCP Connection Failures due to MB-34280 (cluster {{ $labels.couchbase_cluster }})
+          title: DCP Connection Failures due to MB-34280 (cluster {{ $labels.cluster }})
           description: Node {{ $labels.hostname }} has reported failures establishing DCP connections due to long connection names (known issue MB-34280).
           remediation: Reduce the lengths of your nodes' hostnames, or contact Couchbase Technical Support.
 
@@ -62,7 +62,7 @@ groups:
         expr: |
           sum(count_over_time(
             {file="memcached.log"} |= "Response::setKeylen: key cannot exceed 1 byte" | json hostname="hostname" [5m]
-          )) by (couchbase_cluster, hostname) > 0
+          )) by (cluster, hostname) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -70,9 +70,9 @@ groups:
           severity: critical
           health_check_id: CB90033
           health_check_name: longDcpNames
-          cluster: '{{ $labels.couchbase_cluster }}'
+          cluster: '{{ $labels.cluster }}'
         annotations:
-          title: Long DCP Names (MB-34280) (cluster {{ $labels.couchbase_cluster }})
+          title: Long DCP Names (MB-34280) (cluster {{ $labels.cluster }})
           description: Node {{ $labels.hostname }} has reported errors due to long connection names (known issue MB-34280).
           remediation: Reduce the lengths of your nodes' hostnames, or contact Couchbase Technical Support.
 

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -5,7 +5,7 @@ groups:
 
       - alert: CB90036-memcachedCrash
         expr: |
-          count_over_time({file="memcached.log"} |= "Breakpad caught crash" | json | label_format cluster=couchbase_cluster [1h]) > 0
+          count_over_time({file="memcached.log"} |= "Breakpad caught crash" | json | label_format cluster=couchbase_cluster [1h])
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -75,22 +75,3 @@ groups:
           title: Long DCP Names (MB-34280) (cluster {{ $labels.couchbase_cluster }})
           description: Node {{ $labels.hostname }} has reported errors due to long connection names (known issue MB-34280).
           remediation: Reduce the lengths of your nodes' hostnames, or contact Couchbase Technical Support.
-
-      - alert: CB90044-babysitterManagedProcessCrash
-        expr: |
-          count_over_time({file="babysitter.log"} |~ ".*Cushion managed supervisor for.*failed:.*" | label_format cluster=couchbase_cluster | json message="message" | line_format "{{.message}}" | pattern "<_>Cushion managed supervisor for <process> failed: <reason>" [1h]) > 0
-        for: 1m
-        labels:
-          job: couchbase_fluent_bit
-          kind: node
-          severity: critical
-          health_check_id: CB90044
-          health_check_name: babysitterManagedProcessCrash
-          cluster: '{{ $labels.cluster }}'
-          node: '{{ $labels.hostname }}'
-          process: '{{ $labels.process }}'
-          reason: '{{$labels.reason}}'
-        annotations:
-          title: Process managed by babysitter has crashed ({{ $labels.hostname }})
-          description: "The following proccess managed by Couchbase Server's babysitter has crashed with the message: {{ $labels.process }} - {{$labels.reason}}"
-          remediation: Contact Couchbase Technical Support.

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -75,3 +75,22 @@ groups:
           title: Long DCP Names (MB-34280) (cluster {{ $labels.couchbase_cluster }})
           description: Node {{ $labels.hostname }} has reported errors due to long connection names (known issue MB-34280).
           remediation: Reduce the lengths of your nodes' hostnames, or contact Couchbase Technical Support.
+
+      - alert: CB90044-babysitterManagedProcessCrash
+        expr: |
+          count_over_time({file="babysitter.log"} |~ ".*Cushion managed supervisor for.*failed:.*" | label_format cluster=couchbase_cluster | json message="message" | line_format "{{.message}}" | pattern "<_>Cushion managed supervisor for <process> failed: <reason>" [1h]) > 0
+        for: 1m
+        labels:
+          job: couchbase_fluent_bit
+          kind: node
+          severity: critical
+          health_check_id: CB90044
+          health_check_name: babysitterManagedProcessCrash
+          cluster: '{{ $labels.cluster }}'
+          node: '{{ $labels.hostname }}'
+          process: '{{ $labels.process }}'
+          reason: '{{$labels.reason}}'
+        annotations:
+          title: Process managed by babysitter has crashed ({{ $labels.hostname }})
+          description: "The following proccess managed by Couchbase Server's babysitter has crashed with the message: {{ $labels.process }} - {{$labels.reason}}"
+          remediation: Contact Couchbase Technical Support.

--- a/testing/helpers/url-helpers.bash
+++ b/testing/helpers/url-helpers.bash
@@ -22,7 +22,9 @@ function wait_for_curl() {
     local MAX_ATTEMPTS=$1
     shift
     local ATTEMPTS=0
-    echo "Curl command: curl -s -o /dev/null -f $*"
+    if [ "${VERBOSITY:-0}" -gt 1 ]; then
+        echo "Curl command: curl -s -o /dev/null -f $*"
+    fi
     until curl -s -o /dev/null -f "$@"; do
         # Prevent an infinite loop - at 2 seconds per go this is 10 minutes
         if [ $ATTEMPTS -gt "300" ]; then

--- a/testing/loki_alerts/Couchbase-Server/CB90033-longDcpNames-failedResponse/memcached.log.000000.txt
+++ b/testing/loki_alerts/Couchbase-Server/CB90033-longDcpNames-failedResponse/memcached.log.000000.txt
@@ -1,0 +1,6 @@
+2022-01-11T15:24:42.866891+00:00 INFO Couchbase version 7.0.2-6703 starting.
+2022-01-11T15:24:42.866944+00:00 INFO recalculate_max_connections: {"max_fds":1048576,"max_connections":60000,"system_connections":5000,"engine_fds":987549}
+2022-01-11T15:24:42.866955+00:00 INFO Breakpad disabled
+2022-01-11T15:24:42.867345+00:00 INFO Using SLA configuration: {"COMPACT_DB":{"slow":"1800 s"},"CREATE_BUCKET":{"slow":"5 s"},"DELETE_BUCKET":{"slow":"10 s"},"SELECT_BUCKET":{"slow":"10 ms"},"SEQNO_PERSISTENCE":{"slow":"30 s"},"comment":"Current MCBP SLA configuration","default":{"slow":"500 ms"},"version":1}
+2022-01-11T15:24:42.867412+00:00 INFO Enable standard input listener
+2022-01-11T15:24:43.867412+00:00 ERROR 85: exception occurred in runloop during packet execution. Cookie info: [{"aiostat":"success","connection":"[ {\"ip\":\"127.0.0.1\",\"port\":16273} - {\"ip\":\"127.0.0.1\",\"port\":11209} (<ud>@ns_server</ud>) ]","engine_storage":"0x0000000000000000","ewouldblock":false,"packet":{"bodylen":3,"cas":0,"datatype":"raw","extlen":0,"key":"<ud>dcp</ud>","keylen":3,"magic":"ClientRequest","opaque":0,"opcode":"STAT","vbucket":0},"refcount":0}] - closing connection ([ {"ip":"127.0.0.1","port":16273} - {"ip":"127.0.0.1","port":11209} (<ud>@ns_server</ud>) ]): Response::setKeylen: key cannot exceed 1 byte

--- a/testing/loki_alerts/Couchbase-Server/CB90036-memcachedCrash/memcached.log.000000.txt
+++ b/testing/loki_alerts/Couchbase-Server/CB90036-memcachedCrash/memcached.log.000000.txt
@@ -1,0 +1,6 @@
+2022-01-11T15:24:42.866891+00:00 INFO Couchbase version 7.0.2-6703 starting.
+2022-01-11T15:24:42.866944+00:00 INFO recalculate_max_connections: {"max_fds":1048576,"max_connections":60000,"system_connections":5000,"engine_fds":987549}
+2022-01-11T15:24:42.866955+00:00 INFO Breakpad disabled
+2022-01-11T15:24:42.867345+00:00 INFO Using SLA configuration: {"COMPACT_DB":{"slow":"1800 s"},"CREATE_BUCKET":{"slow":"5 s"},"DELETE_BUCKET":{"slow":"10 s"},"SELECT_BUCKET":{"slow":"10 ms"},"SEQNO_PERSISTENCE":{"slow":"30 s"},"comment":"Current MCBP SLA configuration","default":{"slow":"500 ms"},"version":1}
+2022-01-11T15:24:42.867412+00:00 INFO Enable standard input listener
+2022-01-11T15:24:42.982093+00:00 WARNING Breakpad caught crash in memcached. Writing crash dump to /opt/couchbase/var/lib/couchbase/crash/1e4a92b9-e350-b8d2-67b966ba-1b89a355.dmp before terminating.

--- a/testing/loki_alerts/Couchbase-Server/CB90037-slowOperations/memcached.log.000000.txt
+++ b/testing/loki_alerts/Couchbase-Server/CB90037-slowOperations/memcached.log.000000.txt
@@ -1,0 +1,6 @@
+2021-12-31T10:32:53.855923+00:00 INFO ---------- Opening logfile: /opt/couchbase/var/lib/couchbase/logs/memcached.log.000000.txt
+2021-12-31T10:32:53.856861+00:00 INFO Couchbase version 7.0.2-6703 starting.
+2021-12-31T10:32:53.856871+00:00 INFO recalculate_max_connections: {"max_fds":200000,"max_connections":65000,"system_connections":5000,"engine_fds":133982}
+2021-12-31T10:32:53.856906+00:00 INFO Breakpad enabled. Minidumps will be written to '/opt/couchbase/var/lib/couchbase/crash'
+2021-12-31T10:32:53.857135+00:00 INFO Using SLA configuration: {"COMPACT_DB":{"slow":"1800 s"},"CREATE_BUCKET":{"slow":"5 s"},"DELETE_BUCKET":{"slow":"10 s"},"SELECT_BUCKET":{"slow":"10 ms"},"SEQNO_PERSISTENCE":{"slow":"30 s"},"comment":"Current MCBP SLA configuration","default":{"slow":"500 ms"},"version":1}
+2021-12-31T10:33:00.209875+00:00 WARNING 60: Slow operation: {"bucket":"beer-sample","cid":"127.0.0.1:57425/0","command":"SELECT_BUCKET","duration":"13 ms","packet":{"bodylen":11,"cas":0,"datatype":"raw","extlen":0,"key":"<ud>beer-sample</ud>","keylen":11,"magic":"ClientRequest","opaque":0,"opcode":"SELECT_BUCKET","vbucket":0},"peer":"{\"ip\":\"127.0.0.1\",\"port\":57425}","response":"Success","trace":"request=15332435473648:12767 execute=15332435473648:12767","worker_tid":140254451812096}

--- a/testing/loki_alerts/Couchbase-Server/CB90044-babysitterManagedProcessCrash/babysitter.log
+++ b/testing/loki_alerts/Couchbase-Server/CB90044-babysitterManagedProcessCrash/babysitter.log
@@ -1,0 +1,176 @@
+[ns_server:info,2022-01-12T10:10:42.189Z,babysitter_of_ns_1@cb.local:<0.107.0>:ns_babysitter:init_logging:131]Brought up babysitter logging
+[ns_server:info,2022-01-12T10:10:42.197Z,babysitter_of_ns_1@cb.local:<0.107.0>:ns_babysitter:log_pending:96]Static config terms:
+[{error_logger_mf_dir,"/opt/couchbase/var/lib/couchbase/logs"},
+ {path_config_bindir,"/opt/couchbase/bin"},
+ {path_config_etcdir,"/opt/couchbase/etc/couchbase"},
+ {path_config_libdir,"/opt/couchbase/lib"},
+ {path_config_datadir,"/opt/couchbase/var/lib/couchbase"},
+ {path_config_tmpdir,"/opt/couchbase/var/lib/couchbase/tmp"},
+ {path_config_secdir,"/opt/couchbase/etc/security"},
+ {nodefile,"/opt/couchbase/var/lib/couchbase/couchbase-server.node"},
+ {loglevel_default,debug},
+ {loglevel_couchdb,info},
+ {loglevel_ns_server,debug},
+ {loglevel_error_logger,debug},
+ {loglevel_user,debug},
+ {loglevel_menelaus,debug},
+ {loglevel_ns_doctor,debug},
+ {loglevel_stats,debug},
+ {loglevel_rebalance,debug},
+ {loglevel_cluster,debug},
+ {loglevel_views,debug},
+ {loglevel_mapreduce_errors,debug},
+ {loglevel_xdcr,debug},
+ {loglevel_access,info},
+ {loglevel_cbas,debug},
+ {disk_sink_opts,[{rotation,[{compress,true},
+                             {size,41943040},
+                             {num_files,10},
+                             {buffer_size_max,52428800}]}]},
+ {disk_sink_opts_json_rpc,[{rotation,[{compress,true},
+                                      {size,41943040},
+                                      {num_files,2},
+                                      {buffer_size_max,52428800}]}]},
+ {net_kernel_verbosity,10}]
+[ns_server:debug,2022-01-12T10:10:42.199Z,babysitter_of_ns_1@cb.local:<0.107.0>:dist_manager:configure_net_kernel:297]Set net_kernel vebosity to 10 -> 0
+  MFA: {supervisor_cushion,start_link,
+                           [cbas,5000,infinity,ns_port_server,start_link,
+                            [#Fun<ns_child_ports_sup.4.44980406>]]}
+[error_logger:info,2022-01-12T10:10:51.906Z,babysitter_of_ns_1@cb.local:ns_child_ports_sup<0.124.0>:ale_error_logger_handler:do_log:101]
+=========================PROGRESS REPORT=========================
+    supervisor: {local,ns_child_ports_sup}
+    started: [{pid,<0.300.0>},
+              {id,{cbas,"/opt/couchbase/bin/cbas",
+                      ["-serverPort=8091","-serverSslPort=18091",
+                       "-bindHttpPort=8095","-bindAdminPort=9110",
+                       "-debugPort=-1","-ccHttpPort=9111",
+                       "-ccClusterPort=9112","-ccClientPort=9113",
+                       "-consolePort=9114","-clusterPort=9115",
+                       "-dataPort=9116","-resultPort=9117",
+                       "-messagingPort=9118","-metadataPort=9121",
+                       "-metadataCallbackPort=9119","-parentPort=9122",
+                       "-bindReplicationPort=9120","-bindHttpsPort=18095",
+                       "-tlsCertFile=/opt/couchbase/var/lib/couchbase/config/memcached-cert.pem",
+                       "-tlsKeyFile=/opt/couchbase/var/lib/couchbase/config/memcached-key.pem",
+                       "-uuid=a1bfe960d241eae8dbffe4c7cedab56c",
+                       "-serverAddress=127.0.0.1",
+                       "-bindHttpAddress=127.0.0.1",
+                       "-cbasExecutable=/opt/couchbase/bin/cbas",
+                       "-memoryQuotaMb=1024",
+                       "-logDir=/opt/couchbase/var/lib/couchbase/logs",
+                       "-tmpDir=/opt/couchbase/var/lib/couchbase/tmp",
+                       "-logRotationSize=41943040","-logRotationNumFiles=10",
+                       "-logLevel=debug",
+                       "-dataDir=/opt/couchbase/var/lib/couchbase/data/@analytics",
+                       "-ipv4=required","-ipv6=optional"],
+                      [via_goport,exit_status,stderr_to_stdout,
+                       {env,
+                           [{"GOTRACEBACK","single"},
+                            {"CBAUTH_REVRPC_URL",
+                             <<85,67,24,135,97,12,41,196,112,251,160,160,
+                               169,121,189,3,192,147,212,160,222,67,247,154,
+                               119,69,12,206,220,21,64,144>>}]},
+                       {log,"analytics_info.log"}]}},
+              {mfargs,
+                  {restartable,start_link,
+                      [{supervisor_cushion,start_link,
+                           [cbas,5000,infinity,ns_port_server,start_link,
+                            [#Fun<ns_child_ports_sup.4.44980406>]]},
+                       86400000]}},
+              {restart_type,permanent},
+              {shutdown,infinity},
+              {child_type,worker}]
+[ns_server:debug,2022-01-12T10:10:52.009Z,babysitter_of_ns_1@cb.local:cbas-goport<0.367.0>:goport:handle_eof:576]Stream 'stderr' closed
+[ns_server:debug,2022-01-12T10:10:52.009Z,babysitter_of_ns_1@cb.local:cbas-goport<0.367.0>:goport:handle_eof:576]Stream 'stdout' closed
+[ns_server:info,2022-01-12T10:10:52.012Z,babysitter_of_ns_1@cb.local:cbas-goport<0.367.0>:goport:handle_process_exit:557]Port exited with status 1.
+[error_logger:error,2022-01-12T10:10:52.016Z,babysitter_of_ns_1@cb.local:<0.302.0>:ale_error_logger_handler:do_log:101]
+=========================ERROR REPORT=========================
+** Generic server <0.302.0> terminating
+** Last message in was {<0.367.0>,{exit_status,1}}
+** When Server state == {state,<0.367.0>,
+                            {cbas,"/opt/couchbase/bin/cbas",
+                                ["-serverPort=8091","-serverSslPort=18091",
+                                 "-bindHttpPort=8095","-bindAdminPort=9110",
+                                 "-debugPort=-1","-ccHttpPort=9111",
+                                 "-ccClusterPort=9112","-ccClientPort=9113",
+                                 "-consolePort=9114","-clusterPort=9115",
+                                 "-dataPort=9116","-resultPort=9117",
+                                 "-messagingPort=9118","-metadataPort=9121",
+                                 "-metadataCallbackPort=9119",
+                                 "-parentPort=9122",
+                                 "-bindReplicationPort=9120",
+                                 "-bindHttpsPort=18095",
+                                 "-tlsCertFile=/opt/couchbase/var/lib/couchbase/config/memcached-cert.pem",
+                                 "-tlsKeyFile=/opt/couchbase/var/lib/couchbase/config/memcached-key.pem",
+                                 "-uuid=a1bfe960d241eae8dbffe4c7cedab56c",
+                                 "-serverAddress=127.0.0.1",
+                                 "-bindHttpAddress=127.0.0.1",
+                                 "-cbasExecutable=/opt/couchbase/bin/cbas",
+                                 "-memoryQuotaMb=1024",
+                                 "-logDir=/opt/couchbase/var/lib/couchbase/logs",
+                                 "-tmpDir=/opt/couchbase/var/lib/couchbase/tmp",
+                                 "-logRotationSize=41943040",
+                                 "-logRotationNumFiles=10","-logLevel=debug",
+                                 "-dataDir=/opt/couchbase/var/lib/couchbase/data/@analytics",
+                                 "-ipv4=required","-ipv6=optional"],
+                                [via_goport,exit_status,stderr_to_stdout,
+                                 {env,
+                                     [{"GOTRACEBACK","single"},
+                                      {"CBAUTH_REVRPC_URL",
+                                       "http://%40:452d4a267df9dce3c07f0d928f1d579a@127.0.0.1:8091/cbas"}]}]},
+                            {ringbuffer,997,1024,
+                                {[{<<"2022-01-12T10:10:52.007+00:00 FATA CBAS.cbas error validating java home: unable to determine java version: exit status 1\n">>,
+                                   121},
+                                  {<<"2022-01-12T10:10:51.930+00:00 INFO CBAS.cbas setting java.home to bundled jre (/opt/couchbase/lib/cbas/runtime)\n">>,
+                                   112},
+                                  {<<"2022-01-12T10:10:51.930+00:00 INFO CBAS.cbas io devices were adjusted to a total of: 1\n">>,
+                                   87},
+                                  {<<"2022-01-12T10:10:51.930+00:00 INFO CBAS.cbas configuring io devices based on available memory (1024): 1\n">>,
+                                   104},
+                                  {<<"2022-01-12T10:10:51.930+00:00 INFO CBAS.cbas a single io device was provided; auto-adjusting...\n">>,
+                                   96},
+                                  {<<"2022-01-12T10:10:51.930+00:00 INFO CBAS.cbas IPv4 addresses: [127.0.0.1 172.31.0.2]\n2022-01-12T10:10:51.930+00:00 INFO CBAS.cbas IPv6 addresses: []\n2022-01-12T10:10:51.930+00:00 INFO CBAS.cbas setting ipv4 required, ipv6 optional\n">>,
+                                   230},
+                                  {<<"2022-01-12T10:10:51.929+00:00 INFO CBAS.cbas uuid: a1bfe960d241eae8dbffe4c7cedab56c\n">>,
+                                   84},
+                                  {<<"2022-01-12T10:10:51.929+00:00 INFO CBAS.cbas ++++++++++++ starting cbas main ++++++++++++\n">>,
+                                   90}],
+                                 [{<<"2022-01-12T10:10:51.928+00:00 WARN CBAS.cbas Updating log level to DEBUG\n">>,
+                                   73}]}},
+                            cbas,undefined,[],0}
+** Reason for termination ==
+** {abnormal,1}
+
+[error_logger:error,2022-01-12T10:10:52.027Z,babysitter_of_ns_1@cb.local:<0.302.0>:ale_error_logger_handler:do_log:101]
+=========================CRASH REPORT=========================
+  crasher:
+    initial call: ns_port_server:init/1
+    pid: <0.302.0>
+    registered_name: []
+    exception exit: {abnormal,1}
+      in function  gen_server:handle_common_reply/8 (gen_server.erl, line 751)
+    ancestors: [<0.301.0>,<0.300.0>,ns_child_ports_sup,ns_babysitter_sup,
+                  <0.107.0>]
+    message_queue_len: 1
+    messages: [{'EXIT',<0.367.0>,normal}]
+    links: [<0.301.0>]
+    dictionary: []
+    trap_exit: true
+    status: running
+    heap_size: 4185
+    stack_size: 27
+    reductions: 69064
+  neighbours:
+
+[ns_server:info,2022-01-12T10:10:52.027Z,babysitter_of_ns_1@cb.local:<0.301.0>:supervisor_cushion:handle_info:54]Cushion managed supervisor for cbas failed:  {abnormal,1}
+[ns_server:info,2022-01-12T10:10:52.027Z,babysitter_of_ns_1@cb.local:<0.301.0>:supervisor_cushion:die_slowly:76]Service cbas exited on node 'babysitter_of_ns_1@cb.local' in 0.40s
+
+[error_logger:info,2022-01-12T10:10:52.028Z,babysitter_of_ns_1@cb.local:kernel_safe_sup<0.80.0>:ale_error_logger_handler:do_log:101]
+=========================PROGRESS REPORT=========================
+    supervisor: {local,kernel_safe_sup}
+    started: [{pid,<0.379.0>},
+              {id,timer_server},
+              {mfargs,{timer,start_link,[]}},
+              {restart_type,permanent},
+              {shutdown,1000},
+              {child_type,worker}]

--- a/testing/loki_alerts/README.md
+++ b/testing/loki_alerts/README.md
@@ -10,4 +10,5 @@ This directory contains scripts and helpers for testing our Loki alerting rules.
 2. Place the log files that should trigger that rule in that directory.
     * These must be named as they would be on a running Couchbase Server (so if you're using a cbcollect make sure to trim off the `ns_server.` prefix)
     * These MUST NOT contain any customer data! Where possible, use logs from your own reproduction of the issue.
+    * Due to the way we handle times, ensure that the sample log lines don't cover more than an hour or so
 3. To verify, run `./run_single_test.sh <group name>/<rule name>`.

--- a/testing/loki_alerts/README.md
+++ b/testing/loki_alerts/README.md
@@ -1,0 +1,13 @@
+# Loki alert unit testing
+
+This directory contains scripts and helpers for testing our Loki alerting rules.
+
+**NB**: As a simplification, these tests only test that the alert's LogQL query matches. It does not check the alert labels.
+
+## Adding a new test
+
+1. Create a new directory called `<group name>/<rule name>` in this folder, where `<group name>` and `<rule name>` come from the YAML rules definition file (in microlith/loki/alerting/couchbase).
+2. Place the log files that should trigger that rule in that directory.
+    * These must be named as they would be on a running Couchbase Server (so if you're using a cbcollect make sure to trim off the `ns_server.` prefix)
+    * These MUST NOT contain any customer data! Where possible, use logs from your own reproduction of the issue.
+3. To verify, run `./run_single_test.sh <group name>/<rule name>`.

--- a/testing/loki_alerts/fluent-bit.header.conf
+++ b/testing/loki_alerts/fluent-bit.header.conf
@@ -1,0 +1,8 @@
+[SERVICE]
+    flush           1
+    log_level       Debug
+    parsers_file    /fluent-bit/etc/parsers-couchbase.conf
+    HTTP_Server     On
+    storage.metrics On
+    HTTP_Port       ${HTTP_PORT}
+    Health_Check    On

--- a/testing/loki_alerts/fluent-bit.trailer.conf
+++ b/testing/loki_alerts/fluent-bit.trailer.conf
@@ -1,0 +1,43 @@
+# Deal specifically with some log parsing initially
+@include /fluent-bit/etc/couchbase/filter-handle-logfmt.conf
+
+# Add in common info
+@include /fluent-bit/etc/couchbase/filter-add-common-info.conf
+
+# Deal with missing/incorrect level & filename information
+@include /fluent-bit/etc/couchbase/filter-handle-levels.conf
+@include /fluent-bit/etc/couchbase/filter-handle-filenames.conf
+
+# Optionally include this to get common problems duplicated to a specific stream
+# @include /fluent-bit/etc/couchbase/filter-common-problems.conf
+
+# TEST SPECIFIC: Loki only lets us query a 12 hour window at most.
+# Rather than parsing all the logs _again_ to determine when they start,
+# we'll remap the timestamps in the logs to start from now-ish.
+[FILTER]
+    Name lua
+    Match *
+    Script rebase_times.lua
+    Call cb_rebase_times
+
+# Output all parsed Couchbase logs by default
+@include /fluent-bit/etc/couchbase/out-stdout.conf
+
+# Send to loki: refer to configuration guide
+# Do not make too many labels: https://grafana.com/blog/2020/08/27/the-concise-guide-to-labels-in-loki/
+[OUTPUT]
+    Name        loki
+    Alias       loki_output
+    # Disable matching by default, to enable it pass the value as a variable.
+    # With CAO, this can be done via a user-defined annotation, e.g.: fluentbit.couchbase.com/loki.match="*"
+    Match       *
+    # These should be set in the environment, defaulted in the container
+    Host        ${LOKI_HOST}
+    Port        ${LOKI_PORT}
+    tenant_id   ${LOKI_TENANT}
+    Labels      job=couchbase-fluentbit
+    # These should be present in the log record - see the `filter-handle-*.conf` as well
+    Label_keys  $file,$level,$couchbase['cluster'],$couchbase['node']
+    Workers     1
+    # Loki does not support out-of-order streams so no point retrying as soon as we hit a failure
+    Retry_Limit no_retries

--- a/testing/loki_alerts/fluent-bit.trailer.conf
+++ b/testing/loki_alerts/fluent-bit.trailer.conf
@@ -19,6 +19,7 @@
     Match *
     Script rebase_times.lua
     Call cb_rebase_times
+    Time_as_table true
 
 # Output all parsed Couchbase logs by default
 @include /fluent-bit/etc/couchbase/out-stdout.conf

--- a/testing/loki_alerts/rebase_times.lua
+++ b/testing/loki_alerts/rebase_times.lua
@@ -1,0 +1,15 @@
+tag_first_timestamps = {}
+tag_first_seen_wall_clock_times = {}
+
+function cb_rebase_times(tag, timestamp, record)
+    for test_tag, first_ts in pairs(tag_first_timestamps) do
+        if tag == test_tag then
+            new_ts = (timestamp - first_ts) + tag_first_seen_wall_clock_times[tag]
+            return 1, new_ts, record
+        end
+    end
+
+    tag_first_timestamps[tag] = timestamp
+    tag_first_seen_wall_clock_times[tag] = os.time() - (60 * 30) -- shift it back an hour, just in case
+    return 0, timestamp, record
+end

--- a/testing/loki_alerts/rebase_times.lua
+++ b/testing/loki_alerts/rebase_times.lua
@@ -1,15 +1,59 @@
 tag_first_timestamps = {}
 tag_first_seen_wall_clock_times = {}
 
+function dump(o)
+    if type(o) == 'table' then
+       local s = '{ '
+       for k,v in pairs(o) do
+          if type(k) ~= 'number' then k = '"'..k..'"' end
+          s = s .. '['..k..'] = ' .. dump(v) .. ','
+       end
+       return s .. '} '
+    else
+       return tostring(o)
+    end
+ end
+
+ ns_in_1s = 1000000000
+
+function add_time_tables(t1, t2)
+    local new_s = t1["sec"] + t2["sec"]
+    local new_ns = t1["nsec"] + t2["nsec"]
+    if new_ns > ns_in_1s then
+        new_s = new_s + math.floor(new_ns / ns_in_1s)
+        new_ns = new_ns % ns_in_1s
+    end
+    return {sec=new_s, nsec=new_ns}
+end
+
+function sub_time_tables(t1, t2)
+    local new_s = t1["sec"] - t2["sec"]
+    local new_ns = t1["nsec"] - t2["nsec"]
+    if new_ns < 0 then
+        new_s = new_s + math.floor(new_ns / ns_in_1s)
+        new_ns = new_ns % ns_in_1s
+    end
+    return {sec=new_s, nsec=new_ns}
+end
+
 function cb_rebase_times(tag, timestamp, record)
+    local found = false
     for test_tag, first_ts in pairs(tag_first_timestamps) do
         if tag == test_tag then
-            new_ts = (timestamp - first_ts) + tag_first_seen_wall_clock_times[tag]
-            return 1, new_ts, record
+            found = true
+            break
         end
     end
 
-    tag_first_timestamps[tag] = timestamp
-    tag_first_seen_wall_clock_times[tag] = os.time() - (60 * 30) -- shift it back an hour, just in case
-    return 0, timestamp, record
+    if not found then
+        tag_first_timestamps[tag] = timestamp
+        tag_first_seen_wall_clock_times[tag] = math.floor(os.time() - (60 * 30)) -- shift it back an hour, just in case
+        print("Adding", tag, dump(timestamp), dump(tag_first_timestamps), dump(tag_first_seen_wall_clock_times))
+    end
+
+    local new_ts = add_time_tables(sub_time_tables(timestamp, tag_first_timestamps[tag]), {sec=tag_first_seen_wall_clock_times[tag], nsec=0})
+    -- The "timestamp" record key (string) will now be nonsense, so remove it - downstream should be using the Loki timestamp anyway
+    record["timestamp"] = nil
+    print(1, tag, dump(timestamp), dump(new_ts))
+    return 1, new_ts, record
 end

--- a/testing/loki_alerts/rebase_times.lua
+++ b/testing/loki_alerts/rebase_times.lua
@@ -1,19 +1,6 @@
 tag_first_timestamps = {}
 tag_first_seen_wall_clock_times = {}
 
-function dump(o)
-    if type(o) == 'table' then
-       local s = '{ '
-       for k,v in pairs(o) do
-          if type(k) ~= 'number' then k = '"'..k..'"' end
-          s = s .. '['..k..'] = ' .. dump(v) .. ','
-       end
-       return s .. '} '
-    else
-       return tostring(o)
-    end
- end
-
  ns_in_1s = 1000000000
 
 function add_time_tables(t1, t2)
@@ -48,12 +35,10 @@ function cb_rebase_times(tag, timestamp, record)
     if not found then
         tag_first_timestamps[tag] = timestamp
         tag_first_seen_wall_clock_times[tag] = math.floor(os.time() - (60 * 30)) -- shift it back an hour, just in case
-        print("Adding", tag, dump(timestamp), dump(tag_first_timestamps), dump(tag_first_seen_wall_clock_times))
     end
 
     local new_ts = add_time_tables(sub_time_tables(timestamp, tag_first_timestamps[tag]), {sec=tag_first_seen_wall_clock_times[tag], nsec=0})
     -- The "timestamp" record key (string) will now be nonsense, so remove it - downstream should be using the Loki timestamp anyway
     record["timestamp"] = nil
-    print(1, tag, dump(timestamp), dump(new_ts))
     return 1, new_ts, record
 end

--- a/testing/loki_alerts/run_all.sh
+++ b/testing/loki_alerts/run_all.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start Loki, run run_single_test.sh for each test case, then clean up.
+# Logs will be written to a Loki tenant named the same as the test suite, to ensure tests are isolated from each other.
+#
+# Usage: run_all.sh [OPTIONS]
+#
+# Options:
+#     -v, -vv,-vvv, --verbosity <value>:    Increase verbosity. The higher the value, the more verbose the output will be.
+#     -s, --skip-teardown:                  Don't remove Loki container after exit. (Env var: SKIP_TEARDOWN)
+#     -l <url>, --loki <url>:               Use an already running Loki instead of starting one up. (Env var: LOKI_HOST)
+#     --loki-port <port>:                   Use a non-default Loki port.
+
+set -ueo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HELPERS_ROOT="$SCRIPT_DIR/../helpers"
+# shellcheck disable=SC1091
+source "$HELPERS_ROOT/url-helpers.bash"
+
+VERBOSITY=0
+SKIP_TEARDOWN=${SKIP_TEARDOWN:-false}
+LOKI_PORT=3100
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --verbosity)
+        VERBOSITY="$2"
+        shift
+        shift
+        ;;
+    -vv)
+        VERBOSITY=2
+        shift
+        ;;
+    -v)
+        VERBOSITY=1
+        shift
+        ;;
+    -s|--skip-teardown)
+        SKIP_TEARDOWN="true"
+        shift
+        ;;
+    -l|--loki)
+        LOKI_HOST="$2"
+        shift
+        shift
+        ;;
+    --loki-port)
+        LOKI_PORT="$2"
+        shift
+        shift
+        ;;
+  esac
+done
+
+export VERBOSITY=$VERBOSITY
+
+# Helper to only print at the given verbosity or above.
+# Parameters:
+# $1: min verbosity to print
+# all others: echoed
+function log() {
+    if [ "$VERBOSITY" -lt "$1" ]; then
+        return
+    fi
+    shift
+    echo "$@"
+}
+
+if [ -z "${LOKI_HOST:-}" ] || [ -z "${LOKI_PORT:-}" ]; then
+    # Start up Loki
+    log 1 "Starting Loki..."
+    loki_container_id=$(docker run --rm -d -p 3100:3100 --name test_loki grafana/loki:2.4.1 -config.file=/etc/loki/local-config.yaml -log.level=debug)
+    log 1 "Waiting for Loki to become ready..."
+    wait_for_url 10 http://localhost:3100/ready
+    log 2 "Loki ready."
+    LOKI_HOST="localhost"
+    LOKI_PORT=3100
+fi
+
+exit_code=0
+
+for case in "$SCRIPT_DIR"/*/*; do
+    log 1 "RUN ${case##"$SCRIPT_DIR/"}"
+    set +e
+    VERBOSITY="$VERBOSITY" LOKI_TEST_RUN_ALL=true "$SCRIPT_DIR/run_single_test.sh" --skip-teardown -l "$LOKI_HOST" --loki-port "$LOKI_PORT" "${case##"$SCRIPT_DIR/"}"
+    test_exit=$?
+    if [ "$test_exit" -ne 0 ]; then
+        exit_code="$test_exit"
+    fi
+done
+
+if [ "$SKIP_TEARDOWN" != "true" ]; then
+    if docker inspect test_loki >/dev/null 2>&1; then
+        docker rm -f "$loki_container_id" >/dev/null
+    fi
+else
+    log 1 "Skipping Loki teardown. To manually tear it down, run docker rm -f test_loki && docker network rm loki_alerts_test"
+fi
+
+exit "$exit_code"

--- a/testing/loki_alerts/run_all.sh
+++ b/testing/loki_alerts/run_all.sh
@@ -81,7 +81,7 @@ function log() {
     echo "$@"
 }
 
-if [ -z "${LOKI_HOST:-}" ] || [ -z "${LOKI_PORT:-}" ]; then
+if [ -z "${LOKI_HOST:-}" ]; then
     # Start up Loki
     log 1 "Starting Loki..."
     loki_container_id=$(docker run --rm -d -p 3100:3100 --name test_loki grafana/loki:2.4.1 -config.file=/etc/loki/local-config.yaml -log.level=debug)

--- a/testing/loki_alerts/run_single_test.sh
+++ b/testing/loki_alerts/run_single_test.sh
@@ -118,7 +118,9 @@ if [ ! -d "$logs_path" ]; then
     exit 1
 fi
 
-expr=$(yq e -e ".groups[] | select(.name == "'"'"$group"'"'") | .rules[] | select(.alert == "'"'"$alert"'"'") | .expr" "$SCRIPT_DIR/../../microlith/loki/alerting/couchbase/couchbase-rules.yaml")
+rules_path="$SCRIPT_DIR/../../microlith/loki/alerting/couchbase/couchbase-rules.yaml"
+log 2 "Looking for expression for $group/$alert in $rules_path"
+expr=$(yq e -e ".groups[] | select(.name == "'"'"$group"'"'") | .rules[] | select(.alert == "'"'"$alert"'"'") | .expr" "$rules_path")
 
 if [ -z "${LOKI_HOST:-}" ]; then
     # Start up Loki

--- a/testing/loki_alerts/run_single_test.sh
+++ b/testing/loki_alerts/run_single_test.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# Copyright 2021 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run a single Loki alerts test suite.
+# Uses Fluent Bit to read in the test data, then runs the alert's query.
+# Logs will be written to a Loki tenant named the same as the test suite, to ensure tests are isolated from each other.
+#
+# Usage: run_single_test.sh [OPTIONS] Group-Name/testName
+#
+# Options:
+#     -v, -vv,-vvv, --verbosity <value>:    Increase verbosity. The higher the value, the more verbose the output will be.
+#     -s, --skip-teardown:                  Don't remove Loki container after exit. (Env var: SKIP_TEARDOWN)
+#     -l <host>, --loki <host>:             Use an already running Loki instead of starting one up. (Env var: LOKI_HOST)
+#     --loki-port <port>:                   Use a non-default Loki port.
+
+set -ueo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HELPERS_ROOT="$SCRIPT_DIR/../helpers"
+# shellcheck disable=SC1091
+source "$HELPERS_ROOT/url-helpers.bash"
+
+VERBOSITY=${VERBOSITY:-0}
+SKIP_TEARDOWN=${SKIP_TEARDOWN:-false}
+LOKI_PORT=3100
+
+while [[ $# -gt 1 ]]; do
+  case $1 in
+    --verbosity)
+        VERBOSITY="$2"
+        shift
+        shift
+        ;;
+    -vv)
+        VERBOSITY=2
+        shift
+        ;;
+    -v)
+        VERBOSITY=1
+        shift
+        ;;
+    -s|--skip-teardown)
+        SKIP_TEARDOWN="true"
+        shift
+        ;;
+    -l|--loki)
+        LOKI_HOST="$2"
+        shift
+        shift
+        ;;
+    --loki-port)
+        LOKI_PORT="$2"
+        shift
+        shift
+        ;;
+  esac
+done
+
+export VERBOSITY=$VERBOSITY
+
+# Helper to only print at the given verbosity or above.
+# Parameters:
+# $1: min verbosity to print
+# all others: echoed
+function log() {
+    if [ "$VERBOSITY" -lt "$1" ]; then
+        return
+    fi
+    shift
+    echo "$@"
+}
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $(basename "$0") Group-Name/alertName"
+    exit 1
+fi
+
+# Helper that maps a Couchbase log file to the Fluent Bit config include used for it
+# Parameters:
+# $1: the Couchbase log file we're working with
+# Echoes the basename (no path) of the file you'd include to parse it
+function fluent_bit_config_for() {
+    case $1 in
+        memcached.log.000000.txt)
+            echo "in-memcached-log.conf"
+            ;;
+        babysitter.log)
+            echo "in-erlang-multiline-log.conf"
+            ;;
+        *)
+            >&2 echo "ERROR: unknown fluent bit config for $1"
+            exit 1
+            ;;
+    esac
+}
+
+suite="$1"
+group=$(echo "$suite" | sed -e 's/\/.*//')
+alert=$(echo "$suite" | sed -e 's/.*\///')
+
+log 2 "Running suite: $suite"
+
+logs_path="$SCRIPT_DIR/$group/$alert"
+if [ ! -d "$logs_path" ]; then
+    echo "$group/$alert has no log files."
+    exit 1
+fi
+
+expr=$(yq e -e ".groups[] | select(.name == "'"'"$group"'"'") | .rules[] | select(.alert == "'"'"$alert"'"'") | .expr" "$SCRIPT_DIR/../../microlith/loki/alerting/couchbase/couchbase-rules.yaml")
+
+if [ -z "${LOKI_HOST:-}" ]; then
+    # Start up Loki
+    log 2 "Starting Loki..."
+    loki_container_id=$(docker run --rm -d -p 3100:3100 --name test_loki grafana/loki:2.4.1 -config.file=/etc/loki/local-config.yaml -log.level=debug)
+    LOKI_HOST="localhost"
+    LOKI_PORT=3100
+fi
+
+log 1 "Waiting for Loki to become ready..."
+wait_for_url 10 http://localhost:3100/ready
+log 2 "Loki ready."
+
+# Generate the Fluent Bit config - we can't just reuse it, because we need to set Read_from_Head or it'll skip straight to the end of the files.
+# Three main parts to it: a header and a trailer, and in between them a section for each config file we're reading]
+log 2 "Generating fluent-bit config..."
+fb_cfg=$(cat "$SCRIPT_DIR/fluent-bit.header.conf")
+
+for f in "$logs_path"/*; do
+    fb_cfg="$fb_cfg
+
+@include /fluent-bit/etc/couchbase/$(fluent_bit_config_for "$(basename "$f")")
+    Read_from_Head True
+"
+done
+
+fb_cfg="$fb_cfg
+$(cat "$SCRIPT_DIR/fluent-bit.trailer.conf")
+"
+
+echo "$fb_cfg" > "$SCRIPT_DIR/fluent-bit.conf"
+log 2 "Fluent Bit config generated and written to $SCRIPT_DIR/fluent-bit.conf"
+
+# Run Fluent Bit over the case's files
+# Would like to use Exit_on_EOF, but that'd require setting it for each individual [INPUT], which is infeasible (also https://github.com/fluent/fluent-bit/issues/3274)
+# Instead we just run FB and wait a bit - long enough for it to dump the full logs under any reasonable circumstances
+log 1 "Starting Fluent Bit..."
+fb_command="docker run --rm -d \
+    --network host \
+    -v "'"'"$logs_path:/opt/couchbase/var/lib/couchbase/logs:ro"'"'" \
+    -v "'"'"$SCRIPT_DIR/fluent-bit.conf:/fluent-bit/config/fluent-bit.conf"'"'" \
+    -v "'"'"$SCRIPT_DIR/rebase_times.lua:/fluent-bit/config/rebase_times.lua"'"'" \
+    -e 'LOKI_MATCH=*' \
+    -e 'LOKI_HOST=$LOKI_HOST' \
+    -e 'LOKI_PORT=$LOKI_PORT' \
+    -e 'LOKI_TENANT=$suite' \
+    --name test_fluentbit \
+    couchbase/fluent-bit:1.1.3"
+log 2 "Command: $fb_command"
+fb_container_id=$(eval "$fb_command")
+
+# Print the logs so we see what's going on.
+if [ "$VERBOSITY" -lt 2 ]; then
+    sleep 10
+else
+    # timeout will abort the script with error 124 without the ||true
+    timeout 10 docker logs -ft "$fb_container_id" || true
+fi
+docker rm -f "$fb_container_id"
+
+# Now, execute the query against Loki and see if we get anything out
+tmpdir=$(mktemp -d)
+# 2 hours ago, as nanoseconds since the Unix epoch
+query_range_start=$(( $(date +%s) - 2 * 60 * 60))000000000
+# dto, but 1 hour in the future, just in case
+query_range_end=$(( $(date +%s) + 60 * 60))000000000
+if [ "$VERBOSITY" -lt 3 ]; then
+    curl_flags="-fsS"
+else
+    curl_flags="-fv"
+fi
+curl "$curl_flags" -o "$tmpdir/query-result.json" -G \
+    -H "X-Scope-OrgID: $suite" \
+    --data-urlencode "query=$expr" \
+    --data-urlencode "start=$query_range_start" \
+    --data-urlencode "end=$query_range_end" \
+    --data-urlencode "direction=BACKWARD" \
+    --data-urlencode "step=1" \
+    "http://$LOKI_HOST:$LOKI_PORT/loki/api/v1/query_range"
+
+# Don't need Loki anymore, kill it now
+if [ "$SKIP_TEARDOWN" != "true" ]; then
+    if docker inspect test_loki >/dev/null 2>&1; then
+        docker rm -f "$loki_container_id" >/dev/null
+    fi
+elif [ -z "${LOKI_TEST_RUN_ALL:-}" ]; then
+    log 1 "Skipping Loki teardown. To manually tear it down, run docker rm -f test_loki && docker network rm loki_alerts_test"
+fi
+
+results=$(jq -r '.data.result | length' "$tmpdir/query-result.json")
+rm -rf "$tmpdir"
+
+log 2 "JQ result: $results"
+
+if [ -z "$results" ] || [ "$results" -eq 0 ]; then
+    echo "FAIL $suite"
+    exit 1
+else
+    echo "PASS $suite"
+    exit 0
+fi


### PR DESCRIPTION
Add a framework for importing a set of logs into Loki (using Fluent Bit), and then asserting that the relevant alerting rule's query matches. Also add a GitHub Action to run it.

Note that this won't test the labels sent to Alertmanager (as that'd be too slow), only whether the query matches.