### PR TITLE
CMOS-250: Quick-fix for Loki startup panics

### DIFF
--- a/microlith/loki/config.yml
+++ b/microlith/loki/config.yml
@@ -30,8 +30,8 @@ ruler:
   alertmanager_url: http://localhost:9093/alertmanager
   enable_alertmanager_v2: true
   # These two are overridden in tests - the default values should track the defaults in https://grafana.com/docs/loki/latest/configuration/#ruler_config
-  evaluation_interval: ${LOKI_RULER_EVALUATION_INTERVAL:1m}
-  resend_delay: ${LOKI_RULER_RESEND_DELAY:1m}
+  evaluation_interval: ${LOKI_RULER_EVALUATION_INTERVAL:-1m}
+  resend_delay: ${LOKI_RULER_RESEND_DELAY:-1m}
   rule_path: /tmp/loki/scratch
   storage:
     type: local


### PR DESCRIPTION
The syntax for env-substitution was slightly wrong in the Loki config file (will raise an upstream docs issue to correct it), and so it would panic on startup.