### PR TITLE
CMOS-248: Add Alerts for Service Crashes

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 78
+personal_ws-1.1 en 82
 AGPL
 CAO
 CMOS
@@ -76,3 +76,7 @@ VM
 ClusterRole
 overcommitted
 memcached
+FTS
+XDCR
+Eventing
+Analytics

--- a/docs/modules/ROOT/partials/cmos-health-checks.adoc
+++ b/docs/modules/ROOT/partials/cmos-health-checks.adoc
@@ -48,7 +48,7 @@ In virtual environments, high CPU steal indicates that the virtual machines migh
 *Further Reading*: https://docs.couchbase.com/server/current/learn/buckets-memory-and-storage/storage.html[Storage]
 
 [#CB90044]
-=== Babysitter Managed Process Crash (CB90043)
+=== Babysitter Managed Process Crash (CB90044)
 
 *Background*: Babysitter is part of Couchbase Server's cluster manager which is responsible for maintaining a variety of Couchbase Server processes.
 If any of the processes managed by the babysitter die, it is responsible for restarting them.
@@ -59,6 +59,68 @@ If any of the processes managed by the babysitter die, it is responsible for res
 However, if it is happening repeatedly or you do notice disruption in your cluster please contact Couchbase Technical Support.
 
 *Further Reading*: https://docs.couchbase.com/server/current/learn/clusters-and-availability/cluster-manager.html[Cluster Manager]
+
+[#CB90046]
+=== Indexer Crash (CB90046)
+
+*Background*: If the Index Service process (`indexer`) crashes, it will be restarted within a few seconds by the cluster manager.
+However, repeated crashes should be investigated as they may be caused by an underlying issue.
+
+*Condition*: A crash is seen in `indexer` logs.
+
+*Remediation*: Review `indexer.log` to identify the cause, or contact Couchbase Technical Support.
+
+*Further Reading*: https://docs.couchbase.com/server/current/learn/services-and-indexes/services/index-service.html[Index Service]
+
+//CB90047 to be added when couchbase-fluent-bit can parse query.log
+
+[#CB90048]
+=== Cross Data Center Replication (XDCR) Crash (CB90048)
+
+*Background*: If the XDCR process (`goxdcr`) crashes, it will be restarted within a few seconds by the cluster manager.
+However, repeated crashes should be investigated as they may be caused by an underlying issue.
+
+*Condition*: A crash is seen in `goxdcr` logs.
+
+*Remediation*: Review `goxdcr.log` to identify the cause, or contact Couchbase Technical Support.
+
+*Further Reading*: https://docs.couchbase.com/server/current/learn/clusters-and-availability/xdcr-overview.html[Cross Data Center Replication]
+
+[#CB90049]
+=== Full Text Search (FTS) Crash (CB90049)
+
+*Background*: If the FTS Service process (`cbft`) crashes, it will be restarted within a few seconds by the cluster manager.
+However, repeated crashes should be investigated as they may be caused by an underlying issue.
+
+*Condition*: A crash is seen in `cbft` logs.
+
+*Remediation*: Review `fts.log` to identify the cause, or contact Couchbase Technical Support.
+
+*Further Reading*: https://docs.couchbase.com/server/current/learn/services-and-indexes/services/search-service.html[Search Service]
+
+[#CB90050]
+=== Eventing Crash (CB90050)
+
+*Background*: If the Eventing Service process crashes, it will be restarted within a few seconds by the cluster manager.
+However, repeated crashes should be investigated as they may be caused by an underlying issue.
+
+*Condition*: A crash is seen in `eventing.log`.
+
+*Remediation*: Review `eventing.log` to identify the cause, or contact Couchbase Technical Support.
+
+*Further Reading*: https://docs.couchbase.com/server/current/learn/services-and-indexes/services/eventing-service.html[Eventing Service]
+
+[#CB90051]
+=== Analytics Crash (CB90051)
+
+*Background*: If the Analytics Service process (`cbas`) crashes, it will be restarted within a few seconds by the cluster manager.
+However, repeated crashes should be investigated as they may be caused by an underlying issue.
+
+*Condition*: A crash is seen in `cbas` logs.
+
+*Remediation*: Review `analytics_debug.log` to identify the cause, or contact Couchbase Technical Support.
+
+*Further Reading*: https://docs.couchbase.com/server/current/learn/services-and-indexes/services/analytics-service.html[Analytics Service]
 
 // end::group-node[]
 

--- a/docs/modules/ROOT/partials/cmos-health-checks.adoc
+++ b/docs/modules/ROOT/partials/cmos-health-checks.adoc
@@ -72,7 +72,7 @@ However, repeated crashes should be investigated as they may be caused by an und
 
 *Further Reading*: https://docs.couchbase.com/server/current/learn/services-and-indexes/services/index-service.html[Index Service]
 
-//CB90047 to be added when couchbase-fluent-bit can parse query.log
+//CB90047 to be added when couchbase-fluent-bit can parse query.log (https://issues.couchbase.com/browse/K8S-2585)
 
 [#CB90048]
 === Cross Data Center Replication (XDCR) Crash (CB90048)

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -173,7 +173,7 @@ groups:
           job: couchbase_fluent_bit
           kind: node
           severity: critical
-          health_check_id: CB90050
+          health_check_id: CB90051
           health_check_name: analyticsCrash
           cluster: '{{ $labels.cluster }}'
           node: '{{ $labels.hostname }}'

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -112,7 +112,7 @@ groups:
           description: The Index Service on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
           remediation: Review indexer.log to identify the cause, or contact Couchbase Technical Support.
 
-# CB90047-queryCrash, currently couchbase-fluent-bit does not work with query.log
+# CB90047-queryCrash, currently couchbase-fluent-bit does not work with query.log (https://issues.couchbase.com/browse/K8S-2585)
 
       - alert: CB90048-goxdcrCrash
         expr: |

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -78,7 +78,7 @@ groups:
 
       - alert: CB90044-babysitterManagedProcessCrash
         expr: |
-          count_over_time({file="babysitter.log"} |~ ".*Cushion managed supervisor for.*failed:.*" | label_format cluster=couchbase_cluster | json message="message" | line_format "{{.message}}" | pattern "<_>Cushion managed supervisor for <process> failed: <reason>" [1h]) > 0
+          count_over_time({file="babysitter.log"} |~ ".*Cushion managed supervisor for.*failed:.*" | json message="message" | line_format "{{.message}}" | pattern "<_>Cushion managed supervisor for <process> failed: <reason>" [1h]) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -97,7 +97,7 @@ groups:
 
       - alert: CB90046-indexerCrash
         expr: |
-          count_over_time({file="indexer.log"} |~ ".*(panic:|fatal error:).*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+          count_over_time({file="indexer.log"} |~ ".*(panic:|fatal error:).*" | json [1h]) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -109,14 +109,14 @@ groups:
           node: '{{ $labels.hostname }}'
         annotations:
           title: Index Service Crash ({{ $labels.hostname }})
-          description: The Index Service on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          description: "Index Service on node: {{ $labels.hostname }} has crashed."
           remediation: Review indexer.log to identify the cause, or contact Couchbase Technical Support.
 
 # CB90047-queryCrash, currently couchbase-fluent-bit does not work with query.log (https://issues.couchbase.com/browse/K8S-2585)
 
       - alert: CB90048-goxdcrCrash
         expr: |
-          count_over_time({file="goxdcr.log"} |~ ".*panic.*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+          count_over_time({file="goxdcr.log"} |~ ".*(panic|SIGABRT:).*" | json [1h]) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -128,12 +128,12 @@ groups:
           node: '{{ $labels.hostname }}'
         annotations:
           title: XDCR Crash ({{ $labels.hostname }})
-          description: XDCR on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          description: "XDCR on node: {{ $labels.hostname }} has crashed."
           remediation: Review goxdcr.log to identify the cause, or contact Couchbase Technical Support.
 
       - alert: CB90049-ftsCrash
         expr: |
-          count_over_time({file="fts.log"} |~ ".*(panic:|fatal error|fatal, err).*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+          count_over_time({file="fts.log"} |~ ".*(panic:|fatal error|fatal, err).*" | json [1h]) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -145,12 +145,12 @@ groups:
           node: '{{ $labels.hostname }}'
         annotations:
           title: Full Text Search Crash ({{ $labels.hostname }})
-          description: FTS on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          description: "FTS Service on node: {{ $labels.hostname }} has crashed."
           remediation: Review fts.log to identify the cause, or contact Couchbase Technical Support.
 
       - alert: CB90050-eventingCrash
         expr: |
-          count_over_time({file="eventing.log"} |~ ".*(panic:|fatal error:).*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+          count_over_time({file="eventing.log"} |~ ".*(panic:|fatal error:).*" | json [1h]) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -162,12 +162,12 @@ groups:
           node: '{{ $labels.hostname }}'
         annotations:
           title: Eventing Crash ({{ $labels.hostname }})
-          description: Eventing on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          description: "Eventing Service on node: {{ $labels.hostname }} has crashed."
           remediation: Review eventing.log to identify the cause, or contact Couchbase Technical Support.
 
       - alert: CB90051-analyticsCrash
         expr: |
-          count_over_time({file="analytics_debug.log"} |~ ".*JVM halting.*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+          count_over_time({file="analytics_debug.log"} |~ ".*JVM halting.*" | json [1h]) > 0
         for: 1m
         labels:
           job: couchbase_fluent_bit
@@ -179,5 +179,5 @@ groups:
           node: '{{ $labels.hostname }}'
         annotations:
           title: Analytics Crash ({{ $labels.hostname }})
-          description: Analytics on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          description: "Analytics on node: {{ $labels.hostname }} has crashed."
           remediation: Review analytics_debug.log to identify the cause, or contact Couchbase Technical Support.

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -94,3 +94,90 @@ groups:
           title: Process managed by babysitter has crashed ({{ $labels.hostname }})
           description: "The following proccess managed by Couchbase Server's babysitter has crashed with the message: {{ $labels.process }} - {{$labels.reason}}"
           remediation: Contact Couchbase Technical Support.
+
+      - alert: CB90046-indexerCrash
+        expr: |
+          count_over_time({file="indexer.log"} |~ ".*(panic:|fatal error:).*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+        for: 1m
+        labels:
+          job: couchbase_fluent_bit
+          kind: node
+          severity: critical
+          health_check_id: CB90046
+          health_check_name: indexerCrash
+          cluster: '{{ $labels.cluster }}'
+          node: '{{ $labels.hostname }}'
+        annotations:
+          title: Index Service Crash ({{ $labels.hostname }})
+          description: The Index Service on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          remediation: Review indexer.log to identify the cause, or contact Couchbase Technical Support.
+
+# CB90047-queryCrash, currently couchbase-fluent-bit does not work with query.log
+
+      - alert: CB90048-goxdcrCrash
+        expr: |
+          count_over_time({file="goxdcr.log"} |~ ".*panic.*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+        for: 1m
+        labels:
+          job: couchbase_fluent_bit
+          kind: node
+          severity: critical
+          health_check_id: CB90048
+          health_check_name: goxdcrCrash
+          cluster: '{{ $labels.cluster }}'
+          node: '{{ $labels.hostname }}'
+        annotations:
+          title: XDCR Crash ({{ $labels.hostname }})
+          description: XDCR on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          remediation: Review goxdcr.log to identify the cause, or contact Couchbase Technical Support.
+
+      - alert: CB90049-ftsCrash
+        expr: |
+          count_over_time({file="fts.log"} |~ ".*(panic:|fatal error|fatal, err).*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+        for: 1m
+        labels:
+          job: couchbase_fluent_bit
+          kind: node
+          severity: critical
+          health_check_id: CB90049
+          health_check_name: ftsCrash
+          cluster: '{{ $labels.cluster }}'
+          node: '{{ $labels.hostname }}'
+        annotations:
+          title: Full Text Search Crash ({{ $labels.hostname }})
+          description: FTS on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          remediation: Review fts.log to identify the cause, or contact Couchbase Technical Support.
+
+      - alert: CB90050-eventingCrash
+        expr: |
+          count_over_time({file="eventing.log"} |~ ".*(panic:|fatal error:).*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+        for: 1m
+        labels:
+          job: couchbase_fluent_bit
+          kind: node
+          severity: critical
+          health_check_id: CB90050
+          health_check_name: eventingCrash
+          cluster: '{{ $labels.cluster }}'
+          node: '{{ $labels.hostname }}'
+        annotations:
+          title: Eventing Crash ({{ $labels.hostname }})
+          description: Eventing on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          remediation: Review eventing.log to identify the cause, or contact Couchbase Technical Support.
+
+      - alert: CB90051-analyticsCrash
+        expr: |
+          count_over_time({file="analytics_debug.log"} |~ ".*JVM halting.*" | json | label_format cluster=couchbase_cluster [1h]) > 0
+        for: 1m
+        labels:
+          job: couchbase_fluent_bit
+          kind: node
+          severity: critical
+          health_check_id: CB90050
+          health_check_name: analyticsCrash
+          cluster: '{{ $labels.cluster }}'
+          node: '{{ $labels.hostname }}'
+        annotations:
+          title: Analytics Crash ({{ $labels.hostname }})
+          description: Analytics on {{ $labels.hostname }} (cluster {{ $labels.cluster }}) has crashed.
+          remediation: Review analytics_debug.log to identify the cause, or contact Couchbase Technical Support.


### PR DESCRIPTION
These alerts are intended to be temporary until it is decided if/how an agent will be used in CMOS.