### PR TITLE
CMOS-257: Fix duplicate health check issues in dashboards

### DIFF
--- a/microlith/grafana/provisioning/dashboards/bucket-overview.json
+++ b/microlith/grafana/provisioning/dashboards/bucket-overview.json
@@ -219,7 +219,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_.*\"&filter=kind=bucket&filter=cluster=${cluster:querystring}&filter=bucket=${bucket:querystring}"
+          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=kind=bucket&filter=cluster=${cluster:querystring}&filter=bucket=${bucket:querystring}"
         }
       ],
       "title": "Bucket Health Issues",

--- a/microlith/grafana/provisioning/dashboards/cluster-overview.json
+++ b/microlith/grafana/provisioning/dashboards/cluster-overview.json
@@ -257,7 +257,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_.*\"&filter=severity=critical"
+          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=severity=critical"
         }
       ],
       "title": "Critical Alerts",
@@ -687,7 +687,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_.*\"&filter=severity=warning"
+          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=severity=warning"
         }
       ],
       "title": "Warnings",
@@ -793,7 +793,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_.*\"&filter=severity=info"
+          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=severity=info"
         }
       ],
       "title": "Info",
@@ -1709,7 +1709,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=cluster=${cluster:querystring}&filter=kind=cluster&filter=job=~\"couchbase_.*\""
+          "urlPath": "/alerts?filter=cluster=${cluster:querystring}&filter=kind=cluster&filter=job=~\"couchbase_(prometheus|fluent_bit)$\""
         }
       ],
       "title": "Cluster Check Status",
@@ -1960,7 +1960,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=cluster=${cluster:querystring}&filter=kind=node&filter=job=~\"couchbase_.*\""
+          "urlPath": "/alerts?filter=cluster=${cluster:querystring}&filter=kind=node&filter=job=~\"couchbase_(prometheus|fluent_bit)$\""
         }
       ],
       "title": "Node Check Status",
@@ -2207,7 +2207,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=cluster=${cluster:querystring}&filter=kind=bucket&filter=job=~\"couchbase_.*\""
+          "urlPath": "/alerts?filter=cluster=${cluster:querystring}&filter=kind=bucket&filter=job=~\"couchbase_(prometheus|fluent_bit)$\""
         }
       ],
       "title": "Bucket Check Status",

--- a/microlith/grafana/provisioning/dashboards/node-overview.json
+++ b/microlith/grafana/provisioning/dashboards/node-overview.json
@@ -494,7 +494,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_.*\"&filter=kind=node&filter=cluster=${cluster:querystring}&filter=node=~\"${node:regex}(?::[0-9]*)$\""
+          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=kind=node&filter=cluster=${cluster:querystring}&filter=node=~\"${node:regex}(?::[0-9]*)$\""
         }
       ],
       "title": "Health Check Warnings",

--- a/microlith/loki/alerting/couchbase/test-rules.yaml
+++ b/microlith/loki/alerting/couchbase/test-rules.yaml
@@ -9,4 +9,4 @@ groups:
         expr: count_over_time({job="cmos-testing"}[1m]) > 0
         for: 0m
         labels:
-          job: couchbase-fluentbit
+          job: couchbase_fluent_bit


### PR DESCRIPTION
Since we plumbed Cluster Monitor into Alertmanager, these panels picked up its alerts, in addition to the checker data they were getting via Prometheus.

Restrict the query to only Prometheus/Loki-triggered alerts.