### PR TITLE
CMOS-271: Allow overriding metrics port when adding cluster

### DIFF
--- a/config-svc/pkg/api/routes_v1_test.go
+++ b/config-svc/pkg/api/routes_v1_test.go
@@ -1,0 +1,179 @@
+// Copyright 2021 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file  except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the  License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/couchbase/tools-common/cbrest"
+	"github.com/couchbase/tools-common/cbvalue"
+	"github.com/couchbaselabs/observability/config-svc/pkg/couchbase"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const basePromConfig = `global:
+    scrapeInterval: 30s
+scrape_configs:
+    - job_name: test
+      static_configs:
+        - targets:
+            - test1
+            - test2
+          labels:
+            foo: bar
+            test: label
+`
+
+func TestPostClustersAdd(t *testing.T) {
+	t.Run("CreateConfig", func(t *testing.T) {
+		promCfgPath, testCluster := setupForTest(t, cbrest.TestClusterOptions{
+			Handlers: map[string]http.HandlerFunc{
+				"GET:/pools/default": func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(&couchbase.PoolsDefault{
+						ClusterName: "Test Cluster",
+						Nodes: []couchbase.Node{
+							{
+								Hostname: "test",
+								Version:  cbvalue.Version7_0_0,
+							},
+						},
+					})
+				},
+			},
+		})
+		defer testCluster.Close()
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters/add", bytes.NewReader([]byte(fmt.Sprintf(`{
+			"hostname": "%s",
+			"couchbaseConfig": {
+				"username": "Administrator",
+				"password": "asdasd",
+				"managementPort": %d
+			}
+		}`, testCluster.Hostname(), testCluster.Port()))))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		h := &Server{
+			baseLogger: zap.NewNop(),
+			logger:     zap.NewNop(),
+			echo:       e,
+			production: true,
+		}
+
+		err := h.PostClustersAdd(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		result, err := os.ReadFile(promCfgPath)
+		require.NoError(t, err)
+		require.Equal(t, basePromConfig+`    # CMOS managed
+    - job_name: couchbase-server-managed-1
+      basic_auth:
+        username: Administrator
+        password: asdasd
+      static_configs:
+        - targets:
+            - test:8091
+          labels:
+            cluster: Test Cluster
+`, string(result))
+	})
+
+	t.Run("CreateConfigCustomMetricsPort", func(t *testing.T) {
+		promCfgPath, testCluster := setupForTest(t, cbrest.TestClusterOptions{
+			Handlers: map[string]http.HandlerFunc{
+				"GET:/pools/default": func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(&couchbase.PoolsDefault{
+						ClusterName: "Test Cluster",
+						Nodes: []couchbase.Node{
+							{
+								Hostname: "test",
+								Version:  cbvalue.Version6_6_0,
+							},
+						},
+					})
+				},
+			},
+		})
+		defer testCluster.Close()
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters/add", bytes.NewReader([]byte(fmt.Sprintf(`{
+			"hostname": "%s",
+			"couchbaseConfig": {
+				"username": "Administrator",
+				"password": "asdasd",
+				"managementPort": %d
+			},
+			"metricsConfig": {
+				"metricsPort": 9999
+			}
+		}`, testCluster.Hostname(), testCluster.Port()))))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		h := &Server{
+			baseLogger: zap.NewNop(),
+			logger:     zap.NewNop(),
+			echo:       e,
+			production: true,
+		}
+
+		err := h.PostClustersAdd(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		result, err := os.ReadFile(promCfgPath)
+		require.NoError(t, err)
+		require.Equal(t, basePromConfig+`    # CMOS managed
+    - job_name: couchbase-server-managed-1
+      basic_auth:
+        username: ""
+        password: ""
+      static_configs:
+        - targets:
+            - test:9999
+          labels:
+            cluster: Test Cluster
+`, string(result))
+	})
+}
+
+func setupForTest(t *testing.T, opts cbrest.TestClusterOptions) (string, *cbrest.TestCluster) {
+	testDir := t.TempDir()
+	promCfg := filepath.Join(testDir, "prometheus.yml")
+	err := os.WriteFile(promCfg, []byte(basePromConfig), 0o666)
+	require.NoError(t, err)
+	require.NoError(t, os.Setenv("PROMETHEUS_CONFIG_FILE", promCfg))
+
+	testCluster := cbrest.NewTestCluster(t, opts)
+	fmt.Println(testCluster.URL())
+	return promCfg, testCluster
+}

--- a/config-svc/pkg/api/v1/cmos_config_api.yaml
+++ b/config-svc/pkg/api/v1/cmos_config_api.yaml
@@ -84,6 +84,12 @@ components:
               type: string
             useTLS:
               type: boolean
+        metricsConfig:
+          type: object
+          additionalProperties: false
+          properties:
+            metricsPort:
+              type: number
         hostname:
           type: string
     ErrorResponse:

--- a/config-svc/pkg/api/v1/generated.go
+++ b/config-svc/pkg/api/v1/generated.go
@@ -24,8 +24,11 @@ type Cluster struct {
 		UseTLS         *bool    `json:"useTLS,omitempty"`
 		Username       string   `json:"username"`
 	} `json:"couchbaseConfig"`
-	Hostname string  `json:"hostname"`
-	Name     *string `json:"name,omitempty"`
+	Hostname      string `json:"hostname"`
+	MetricsConfig *struct {
+		MetricsPort *float32 `json:"metricsPort,omitempty"`
+	} `json:"metricsConfig,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // PostClustersAddJSONBody defines parameters for PostClustersAdd.
@@ -102,7 +105,6 @@ func RegisterHandlers(router EchoRouter, si ServerInterface) {
 // Registers handlers, and prepends BaseURL to the paths, so that the paths
 // can be served under a prefix.
 func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL string) {
-
 	wrapper := ServerInterfaceWrapper{
 		Handler: si,
 	}
@@ -110,26 +112,25 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/clusters/add", wrapper.PostClustersAdd)
 	router.POST(baseURL+"/collectInformation", wrapper.PostCollectInformation)
 	router.GET(baseURL+"/openapi.json", wrapper.GetOpenapiJson)
-
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/5RVTXPjNgz9Kxy2R6+kJJ02q1NTN9NxJ2k89d7SPdAUZHFDESwB2vVk/N87pOX4I/Hu",
-	"5qYhiPeAxwfoWWrsPTpwTLJ+lqQ76FX+HNtIDCF9qqYxbNApOw3oIbABknWrLMFI+oOjBBd1N1cEY3St",
-	"Wbwzu1dOLaAHx1MMnE4aaFW0LOvr6uPFSPLag6yli/0cgtyMpFdEKwxNujsEiYNxixSMBJ/uZgehOaIF",
-	"5YZYcKqHNxI3Ixng32gCNLJ+3N88YPv8UgrOv4DmhNgh8RnEkfw+qlP1DkBfM6Zk41rcyu5Y6awY9MpY",
-	"WefQry+AhcZe7sqQ493xSEycLuRIxpByOmZPdVkep21GsgHSwfj0jLKWf9/OPomb6URgK7gDsa02BpXi",
-	"YgZhaXSSyxoNjnLfA/GNV7oDcVlUrzhXq1WhcrjAsCiHXCrvJuPbv2a3H1LOZiTZsD1qQdyjM4xJT/FP",
-	"rKrLn8XDnCAs1dxYw2sxY6WfxIezVS4h0Lav5UViQA9OeSNreVVUxVV+du6yP0u9HQoqVZMt55Gy6MnE",
-	"GXfSyFpOkXgYH7ppGrl9ZCD+DZv17rnA5UzlvTU655ZfKJWxm8L09WOAVtbyh3I/puUwo+VuQDfHLuIQ",
-	"IR+QxyRggrmsqnfRvmNk8SmbzsVe1o+Je2/Ul2k7cTk+nXHzscuG/oRqGmgERa2BqI3WrjMixb5XYZ1M",
-	"1TRCCQcrsTfF8FCCUUwD9sAdRMp5pUZrQfPEtRh6tSX76ku+vv9NeRn+49JbZZysXbT2VXMzDqD6NEAW",
-	"F4vkXYzsI4s2YC+GEj+YPWdB3UnbQ10kGqMWDomNFgcJQs0xshjfP8xEi0HMovcYWCin7JoMFVs1BrcX",
-	"OxMs4A0Z/gB+2N77k76n/a+765svn7jSerkqKkEetGkHsNwId4bS9jmR4yHrR3kh7QDOJxdb3rQnIJCs",
-	"H59ParhDray4NzqgNdwdrau6LG0Kp+VcX1fXVanzbimVN2VeIm+j/Q5LsOjT/+083i8XH396Afq8+T8A",
-	"AP//pnnkhKIHAAA=",
+	"H4sIAAAAAAAC/5xVTXPjNgz9Kxy2R0dSkk6b1alpmumkkzSZem/pHmgKsrihCJYA7Xoy/u8dUnL8kXh3",
+	"szcNwfcAPDxCz1Jj79GBY5L1syTdQa/y55WNxBDSp2oawwadsg8BPQQ2QLJulSWYSL9zlOii7maK4Apd",
+	"a+bvRPfKqTn04PgBA6eTBloVLcv6ovpwOpG88iBr6WI/gyDXE+kV0RJDk+6OQeJg3DwFI8HH2+lOaIZo",
+	"QbkxFpzq4Q3geiID/BtNgEbWj9ubO9k+vZSCs8+gOTF2SHyEcSJ74GA0fZ8qA3YjyYEG6zdK+bbGDme1",
+	"08Lr/hLYuBaHITtWOhcDvTJW1jn06wthobGXmzLk1eZ4Im6cLuRExpAwHbOnuiz3YeuJbIB0MD7JI2v5",
+	"9/X0o7h8uBHYCu5ADNXGoFJcTCEsjE7DsUaDo9z3mPjSK92BOCuqVzmXy2WhcrjAMC9HLJW3N1fXf02v",
+	"TxImKWvY7rUg7tAZxqSn+CdW1dnP4n5GEBZqZqzhlZiy0k/i5GiVCwg09LU4TRnQg1PeyFqeF1Vxnk3G",
+	"XZ57qYcnSKVqssE9UhY9mSPz3jSylg9IPD5WumwaOQwZiH/DZrUZF7iMVN5bozO2/EypjM2bT18/Bmhl",
+	"LX8ot0uhHDdCuVkH630XcYiQD8hjEjDRnFXVu9K+4yngUzadi72sH1PurVFf3vaBy/HpiJv3XTb2J1TT",
+	"QCMoag1EbbR2lRkp9r0Kq2SqphFKOFiKrSnGQQlG8RCwB+4gUsaVGq0FzTeuxdCrIdkXJ/n6/lflZfiP",
+	"S2+VcbJ20dpXzU05gOrTA7I4nyfvYmQfWbQBezGWeGK2OQvqDtoe6yLRGDV3SGy02AEINcPI4urufipa",
+	"DGIavcfAQjllV2SoGNQY3V5sTDCHN2T4A/h+uPcnfUv7X3bXVyefcqX1cl5Ugjxo045kuRHuDKXtcyDH",
+	"fdaP8kLaEBwHF0PetCcgkKwfnw9quEWtrLgzOqA13O2tq7osbQqn5VxfVBdVqfNuKZU3ZV4ib7P9Dguw",
+	"6NPf9DjfL6cffnoh+rT+PwAA//8bCrtwEAgAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file
@@ -164,7 +165,7 @@ func decodeSpecCached() func() ([]byte, error) {
 
 // Constructs a synthetic filesystem for resolving external references when loading openapi specifications.
 func PathToRawSpec(pathToFile string) map[string]func() ([]byte, error) {
-	var res = make(map[string]func() ([]byte, error))
+	res := make(map[string]func() ([]byte, error))
 	if len(pathToFile) > 0 {
 		res[pathToFile] = rawSpec
 	}
@@ -178,12 +179,12 @@ func PathToRawSpec(pathToFile string) map[string]func() ([]byte, error) {
 // Externally referenced files must be embedded in the corresponding golang packages.
 // Urls can be supported but this task was out of the scope.
 func GetSwagger() (swagger *openapi3.T, err error) {
-	var resolvePath = PathToRawSpec("")
+	resolvePath := PathToRawSpec("")
 
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true
 	loader.ReadFromURIFunc = func(loader *openapi3.Loader, url *url.URL) ([]byte, error) {
-		var pathToFile = url.String()
+		pathToFile := url.String()
 		pathToFile = path.Clean(pathToFile)
 		getSpec, ok := resolvePath[pathToFile]
 		if !ok {

--- a/microlith/html/promwebform.html
+++ b/microlith/html/promwebform.html
@@ -74,6 +74,24 @@
             </label>
           </div>
         </fieldset>
+        <fieldset x-show="doProm">
+        <legend>
+            <h2>Prometheus configuration</h2>
+          </legend>
+          <div>
+            <label for="prometheusPort"
+              >Prometheus Exporter Port:</label
+            >
+            <input
+              type="text"
+              id="prometheusPort"
+              x-model="prometheusPort"
+              required
+            />
+            <br />
+            <em>Note: this field is not necessary (and will be ignored) if the cluster is running Couchbase Server 7.0 or above, as the built-in Prometheus metrics will be used and an exporter is not necessary.</em>
+          </div>
+        </fieldset>
         <fieldset x-show="doCBMM">
           <legend>
             <h2>Couchbase Cluster Monitor configuration</h2>
@@ -162,6 +180,8 @@
             cbmmUsername: "admin",
             cbmmPassword: "password",
 
+            prometheusPort: 9091,
+
             yamlPrometheus: "",
             healthcheckCommand: "",
 
@@ -210,7 +230,7 @@
                 this.yamlPrometheus = `    - job_name: couchbase-server-<cluster name>
       static_config:
         targets:
-          - '${this.hostname}:${this.managementPort}'
+          - '${this.hostname}:${this.prometheusPort ?? this.managementPort}'
           # Add the other nodes in the cluster here
         labels:
           cluster: <cluster name>
@@ -254,6 +274,9 @@
                         managementPort: parseInt(this.managementPort, 10),
                         useTLS: this.useTLS,
                       },
+                      metricsConfig: this.prometheusPort === null || String(this.prometheusPort) === "" ? null : {
+                        metricsPort: parseInt(this.prometheusPort, 10),
+                      }
                     }),
                   })
                     .then(async (resp) => {


### PR DESCRIPTION
People may have their Prometheus exporters on ports other than 9091. Give them an option to override it, while still using the management port for 7.0 clusters.