### PR TITLE
CMOS-279: Ensure we don't mix alerts from different clusters

### DIFF
--- a/microlith/grafana/provisioning/dashboards/cluster-overview.json
+++ b/microlith/grafana/provisioning/dashboards/cluster-overview.json
@@ -257,7 +257,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=severity=critical"
+          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=cluster=\"${cluster:querystring}\"&filter=severity=critical"
         }
       ],
       "title": "Critical Alerts",
@@ -687,7 +687,7 @@
           "method": "GET",
           "queryParams": "",
           "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=severity=warning"
+          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=cluster=\"${cluster:querystring}\"&filter=severity=warning"
         }
       ],
       "title": "Warnings",


### PR DESCRIPTION
In the single cluster overview dashboard we were missing a filter for the cluster in our requests to Alertmanager.