### PR TITLE
CMOS-278: Add alert for KV connection limit

### DIFF
--- a/docs/modules/ROOT/partials/cmos-health-checks.adoc
+++ b/docs/modules/ROOT/partials/cmos-health-checks.adoc
@@ -184,6 +184,28 @@ This is potentially due to other applications locking Couchbase Server files, or
 *Remediation*: Check that there are no other applications locking files in your Couchbase Server directory, and that permissions are correctly configured.
 If this does not solve the problem, please contact Couchbase Support.
 
+[#CB90072]
+=== Data Service Connection Limit (CB90072)
+
+*Background*: By default, the maximum number of connections to the Data Service is limited to 65,000, of which 5,000 are reserved for internal system services.
+If this limit is exceeded, clients will fail to connect to your Couchbase cluster.
+
+The default limit is high enough that it is unlikely to be legitimately exceeded in production.
+If it is exceeded, the most likely cause is application code failing to shut down connections properly.
+
+*Condition*: Warning if the number of connections is above 80% of the default limit (60,000).
+Upgraded to an alert if the limit is exceeded, or log messages are seen that indicate that client connections are being rejected because of the limit.
+
+[NOTE]
+====
+It is possible to modify this limit.
+However, if this is done, you will need to adjust this health check's threshold accordingly, otherwise it may produce false positives or negatives.
+====
+
+*Remediation*: Review your application code to ensure that it is closing Couchbase connections properly.
+
+*Further Reading*: https://docs.couchbase.com/server/current/rest-api/rest-manage-cluster-connections.html[Managing Cluster Connections]
+
 // end::group-node[]
 
 // tag::group-bucket[]

--- a/microlith/loki/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/loki/alerting/couchbase/couchbase-rules.yaml
@@ -328,3 +328,19 @@ groups:
           remediation: Allocate more storage to existing Data Service nodes, or more Data Service nodes to the cluster, and attempt to rerun Auto-Compaction.
             You may also create a new cluster, with more storage, and use unidirectional XDCR to transfer the files over, which should give you the space required for Auto-Compaction.
             If that is not possible, please contact Couchbase Technical Support.
+
+      - alert: CB90072-kvConnectionLimit
+        expr: |
+          count_over_time({file="memcached.log"} |= "Shutting down client as we're running out of connections" [1h]) >0
+        labels:
+          job: couchbase_fluent_bit
+          kind: node
+          severity: critical
+          health_check_id: CB90072
+          health_check_name: kvConnectionLimit
+          cluster: '{{ $labels.couchbase_cluster }}'
+          node: '{{ $labels.hostname }}'
+        annotations:
+          title: "Data Service Connection Limit Exceeded (node: {{ $labels.hostname }})"
+          description: Client connections have been rejected because the maximum number of connections has been exceeded.
+          remediation: Ensure your applications are appropriately closing their Couchbase connections.

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -127,3 +127,22 @@ groups:
         description: The age of items in the disk write queue is over 50 seconds.
         remediation: Review your hardware for malfunctions or sizing issues. 
           If the problem persists, then please contact Couchbase Technical Support. 
+
+    - alert: CB90072-approachingLimit
+      # 80% of the default limit (65,000 total of which 5,000 reserved for the system)
+      expr: |
+        kv_curr_connections > 48000
+      for: 5m
+      labels:
+        job: couchbase_prometheus
+        kind: node
+        health_check_id: CB90072
+        health_check_name: kvConnectionLimit
+        cluster: '{{ $labels.cluster }}'
+        node: '{{ $labels.instance }}'
+        severity: warning
+      annotations:
+        title: "Approaching Data Service Connection Limit (cluster {{ $labels.cluster }})"
+        description: Node {{ $labels.instance}} has {{ humanize $value }} open Data Service connections out of 60,000.
+          If this limit is exceeded, applications may fail to connect.
+        remediation: Ensure your applications are appropriately closing their Couchbase connections.

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -128,7 +128,7 @@ groups:
         remediation: Review your hardware for malfunctions or sizing issues. 
           If the problem persists, then please contact Couchbase Technical Support. 
 
-    - alert: CB90072-approachingLimit
+    - alert: CB90072-kvConnectionLimit-warn
       # 80% of the default limit (65,000 total of which 5,000 reserved for the system)
       expr: |
         kv_curr_connections > 48000
@@ -145,4 +145,22 @@ groups:
         title: "Approaching Data Service Connection Limit (cluster {{ $labels.cluster }})"
         description: Node {{ $labels.instance}} has {{ humanize $value }} open Data Service connections out of 60,000.
           If this limit is exceeded, applications may fail to connect.
+        remediation: Ensure your applications are appropriately closing their Couchbase connections.
+
+    - alert: CB90072-kvConnectionLimit-alert
+      expr: |
+        kv_curr_connections > 60000
+      for: 5m
+      labels:
+        job: couchbase_prometheus
+        kind: node
+        health_check_id: CB90072
+        health_check_name: kvConnectionLimit
+        cluster: '{{ $labels.cluster }}'
+        node: '{{ $labels.instance }}'
+        severity: critical
+      annotations:
+        title: "Exceeded Data Service Connection Limit (cluster {{ $labels.cluster }})"
+        description: Node {{ $labels.instance}} has {{ humanize $value }} open Data Service connections out of 60,000.
+          Applications may fail to connect.
         remediation: Ensure your applications are appropriately closing their Couchbase connections.


### PR DESCRIPTION
There's also a Hazelnut rule in https://review.couchbase.org/c/cbmultimanager/+/170676.