### PR TITLE
Updated Existing Dashboards

### DIFF
--- a/microlith/grafana/provisioning/dashboards/bucket-overview.json
+++ b/microlith/grafana/provisioning/dashboards/bucket-overview.json
@@ -20,10 +20,9 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": null,
   "graphTooltip": 0,
-  "id": 12,
-  "iteration": 1639146577623,
+  "id": 47,
+  "iteration": 1645034126639,
   "links": [
     {
       "asDropdown": false,
@@ -45,7 +44,10 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": "-- Mixed --",
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -177,6 +179,13 @@
       },
       "id": 43,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": [
           {
@@ -185,41 +194,19 @@
           }
         ]
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "datasource": "Prometheus",
-          "exemplar": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
+          "exemplar": false,
           "expr": "multimanager_bucket_checker_status{cluster_uuid=\"$cluster_uuid\",bucket=\"$bucket\"} >= 0",
           "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
-        },
-        {
-          "cacheDurationSeconds": 5,
-          "datasource": "Alertmanager API",
-          "fields": [
-            {
-              "jsonPath": "$[*].labels.health_check_id",
-              "name": "id"
-            },
-            {
-              "jsonPath": "$[*].labels.health_check_name",
-              "language": "jsonpath",
-              "name": "name"
-            },
-            {
-              "jsonPath": "[$.labels.severity ~> $map(function($a) {\n$a = \"critical\" ? 30 :\n$a = \"warning\" ? 20 :\n$a = \"info\" ? 10 : -1\n})]",
-              "language": "jsonata",
-              "name": "Value"
-            }
-          ],
-          "hide": false,
-          "method": "GET",
-          "queryParams": "",
-          "refId": "B",
-          "urlPath": "/alerts?filter=job=~\"couchbase_(prometheus|fluent_bit)$\"&filter=kind=bucket&filter=cluster=${cluster:querystring}&filter=bucket=${bucket:querystring}"
         }
       ],
       "title": "Bucket Health Issues",
@@ -265,7 +252,6 @@
       "type": "table"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -317,11 +303,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "avg(kv_vb_perc_mem_resident_ratio{bucket=\"$bucket\",cluster=\"$cluster\",state=\"active\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
+          "exemplar": false,
+          "expr": "avg(kv_vb_perc_mem_resident_ratio{bucket=\"$bucket\",cluster_name=~\"$cluster\",state=\"active\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -332,7 +322,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -375,18 +364,26 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "sum (kv_mem_used_bytes{cluster=\"$cluster\",bucket=\"$bucket\"})",
+          "expr": "sum (kv_mem_used_bytes{cluster_name=\"$cluster\",bucket=\"$bucket\"})",
           "interval": "",
           "legendFormat": "In Memory",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "sum (couch_docs_actual_disk_size{cluster=\"$cluster\",bucket=\"$bucket\"})",
+          "expr": "sum (couch_docs_actual_disk_size{cluster_name=\"$cluster\",bucket=\"$bucket\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "On Disk",
@@ -397,7 +394,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -445,13 +441,24 @@
       },
       "id": 35,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum by (scope, collection) (kv_collection_data_size_bytes{cluster=\"$cluster\",bucket=\"$bucket\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
+          "exemplar": false,
+          "expr": "sum by (scope, collection) (kv_collection_data_size_bytes{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -459,8 +466,12 @@
           "refId": "data_size"
         },
         {
-          "exemplar": true,
-          "expr": "sum by (scope, collection) (kv_collection_item_count{cluster=\"$cluster\",bucket=\"$bucket\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
+          "exemplar": false,
+          "expr": "sum by (scope, collection) (kv_collection_item_count{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -507,7 +518,6 @@
       "type": "table"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -578,8 +588,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "sum by (op) (rate(kv_ops{cluster=`$cluster`,bucket=`$bucket`}[$__rate_interval]))",
+          "expr": "sum by (op) (rate(kv_ops{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "{{ op }}",
           "refId": "A"
@@ -589,7 +603,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -726,26 +739,38 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "avg (kv_ep_mem_low_wat{cluster=\"$cluster\",bucket=\"$bucket\"})",
+          "expr": "sum (kv_ep_mem_low_wat{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "interval": "",
           "legendFormat": "Low Water Mark",
           "refId": "low_wat"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "avg (kv_ep_mem_high_wat{cluster=\"$cluster\",bucket=\"$bucket\"})",
+          "expr": "sum (kv_ep_mem_high_wat{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "High Water Mark",
           "refId": "high_wat"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "kv_mem_used_bytes{cluster=\"$cluster\",bucket=\"$bucket\"}",
+          "expr": "sum(kv_mem_used_bytes{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "Memory Used",
           "refId": "mem_used"
         }
       ],
@@ -753,7 +778,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -823,8 +847,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "sum by (instance) (kv_ep_diskqueue_items{cluster=`$cluster`,bucket=`$bucket`})",
+          "expr": "sum by (instance) (kv_ep_diskqueue_items{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -834,7 +862,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -905,8 +932,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "SHZqSh-7k"
+          },
           "exemplar": true,
-          "expr": "histogram_quantile(0.90, irate(kv_cmd_duration_seconds_bucket{opcode=\"GET\",bucket=\"$bucket\",cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "histogram_quantile(0.90, rate(kv_cmd_duration_seconds_bucket{cluster_name=~\"$cluster\",bucket=~\"$bucket\",opcode=\"GET\"}[$__range]))",
           "interval": "",
           "legendFormat": "{{ instance }}",
           "refId": "A"
@@ -917,7 +948,7 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 32,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [
     "couchbase",
@@ -927,20 +958,20 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
-        "current": {},
-        "datasource": null,
-        "definition": "label_values(multimanager_cluster_checker_status,cluster_name)",
-        "description": null,
-        "error": null,
+        "current": {
+          "selected": true,
+          "text": "",
+          "value": ""
+        },
+        "definition": "label_values(kv_curr_items,cluster_name)",
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Cluster",
         "multi": false,
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_cluster_checker_status,cluster_name)",
+          "query": "label_values(kv_curr_items,cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -950,47 +981,47 @@
         "type": "query"
       },
       {
-        "allValue": null,
-        "current": {},
-        "datasource": null,
-        "definition": "query_result(max by (cluster_uuid) (multimanager_cluster_checker_status{cluster_name=${cluster:doublequote}}))",
-        "description": null,
-        "error": null,
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "definition": "label_values(multimanager_cluster_checker_status{cluster_name=~\"$cluster\"}, cluster_uuid)",
         "hide": 2,
         "includeAll": false,
-        "label": null,
         "multi": false,
         "name": "cluster_uuid",
         "options": [],
         "query": {
-          "query": "query_result(max by (cluster_uuid) (multimanager_cluster_checker_status{cluster_name=${cluster:doublequote}}))",
+          "query": "label_values(multimanager_cluster_checker_status{cluster_name=~\"$cluster\"}, cluster_uuid)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/[{,]cluster_uuid=\"(.+?)\"[,}]/",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
       },
       {
-        "allValue": null,
-        "current": {},
-        "datasource": null,
-        "definition": "query_result(multimanager_bucket_checker_status{cluster_name=${cluster:doublequote}})",
-        "description": null,
-        "error": null,
+        "current": {
+          "selected": true,
+          "text": "",
+          "value": ""
+        },
+        "definition": "label_values(kv_curr_items{cluster_name=~\"$cluster\"}, bucket)",
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Bucket",
         "multi": false,
         "name": "bucket",
         "options": [],
         "query": {
-          "query": "query_result(multimanager_bucket_checker_status{cluster_name=${cluster:doublequote}})",
+          "query": "label_values(kv_curr_items{cluster_name=~\"$cluster\"}, bucket)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/[{,]bucket=\"(.+?)(?::[0-9]*)?\"[,}]/",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
@@ -1017,5 +1048,6 @@
   "timezone": "",
   "title": "Bucket Overview",
   "uid": "H8M3rE5nk",
-  "version": 2
+  "version": 3,
+  "weekStart": ""
 }

--- a/microlith/grafana/provisioning/dashboards/service-data.json
+++ b/microlith/grafana/provisioning/dashboards/service-data.json
@@ -1,4 +1,53 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.3.4"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -20,10 +69,9 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": null,
   "graphTooltip": 0,
-  "id": 12,
-  "iteration": 1638784015203,
+  "id": null,
+  "iteration": 1645035685505,
   "links": [
     {
       "asDropdown": false,
@@ -78,7 +126,6 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -91,7 +138,6 @@
       "type": "row"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -151,11 +197,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "topk(3, sum by (bucket) (kv_ep_data_read_failed{cluster=`$cluster`,bucket=~`${bucket:regex}`}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "topk(3, sum by (bucket) (kv_ep_data_read_failed{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "instant": true,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -166,7 +216,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -226,11 +275,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "topk(3, sum by (bucket) (kv_ep_data_write_failed{cluster=`$cluster`,bucket=~`${bucket:regex}`}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "topk(3, sum by (bucket) (kv_ep_data_write_failed{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "instant": true,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -241,7 +294,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -312,8 +364,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum (irate(kv_ops{cluster=`$cluster`,bucket=~`${bucket:regex}`}[$__rate_interval])) by (bucket)",
+          "expr": "sum (irate(kv_ops{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}[$__rate_interval])) by (bucket)",
           "interval": "",
           "legendFormat": "{{bucket}}",
           "refId": "A"
@@ -381,7 +437,7 @@
           }
         ]
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
           "cacheDurationSeconds": 0,
@@ -482,7 +538,6 @@
       "type": "table"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -523,11 +578,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum(kv_curr_connections{cluster=`$cluster`})",
+          "expr": "sum(kv_curr_connections{cluster_name=~\"$cluster\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -535,8 +594,12 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum(kv_daemon_connections{cluster=`$cluster`})",
+          "expr": "sum(kv_daemon_connections{cluster_name=~\"$cluster\"})",
           "hide": false,
           "instant": false,
           "interval": "",
@@ -544,8 +607,12 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum(kv_system_connections{cluster=`$cluster`})",
+          "expr": "sum(kv_system_connections{cluster_name=~\"$cluster\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "System",
@@ -557,7 +624,6 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -570,7 +636,6 @@
       "type": "row"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -645,8 +710,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "histogram_quantile(\n0.50,\nsum by(le,bucket) (\nrate(kv_cmd_duration_seconds_bucket{cluster=`$cluster`,opcode=\"GET\",bucket=~`${bucket:regex}`}[$__rate_interval])\n)\n)",
+          "expr": "histogram_quantile(\n0.50,\nsum by(le,bucket) (\nrate(kv_cmd_duration_seconds_bucket{cluster_name=~\"$cluster\",bucket=~\"$bucket\",opcode=\"GET\"}[$__rate_interval])\n)\n)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -657,7 +726,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -732,8 +800,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster=`$cluster`,opcode=\"GET\",bucket=~`${bucket:regex}`}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster_name=~\"$cluster\",bucket=~\"$bucket\",opcode=\"GET\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -744,7 +816,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -816,8 +887,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "histogram_quantile(0.999, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster=`$cluster`,opcode=\"GET\",bucket=~`${bucket:regex}`}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.999, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster_name=~\"$cluster\",bucket=~\"$bucket\",opcode=\"GET\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -828,7 +903,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -900,8 +974,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster=`$cluster`,opcode=\"SET\",bucket=~`${bucket:regex}`}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster_name=~\"$cluster\",bucket=~\"$bucket\",opcode=\"SET\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -912,7 +990,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -984,8 +1061,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster=`$cluster`,opcode=\"SET\",bucket=~`${bucket:regex}`}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster_name=~\"$cluster\",bucket=~\"$bucket\",opcode=\"SET\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -996,7 +1077,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1068,8 +1148,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "histogram_quantile(0.999, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster=`$cluster`,opcode=\"SET\",bucket=~`${bucket:regex}`}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.999, sum by(le,bucket) (rate(kv_cmd_duration_seconds_bucket{cluster_name=~\"$cluster\",bucket=~\"$bucket\",opcode=\"SET\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{bucket}}",
@@ -1080,7 +1164,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 8,
@@ -1092,12 +1175,11 @@
         "content": "# Number of documents #",
         "mode": "markdown"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 8,
@@ -1109,12 +1191,11 @@
         "content": "# Dataset size on disk #",
         "mode": "markdown"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 8,
@@ -1126,12 +1207,11 @@
         "content": "# Dataset size in memory #",
         "mode": "markdown"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1175,13 +1255,17 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "repeat": "bucket",
       "repeatDirection": "v",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum by (bucket) (kv_curr_items{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "sum by (bucket) (kv_curr_items{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{ bucket }}",
@@ -1191,7 +1275,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1233,13 +1316,17 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "repeat": "bucket",
       "repeatDirection": "v",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "topk(3, sum by (bucket) (couch_docs_actual_disk_size{cluster=`$cluster`,bucket=~`${bucket:regex}`}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "topk(3, sum by (bucket) (couch_docs_actual_disk_size{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "instant": true,
           "interval": "",
           "legendFormat": "{{ bucket }}",
@@ -1249,7 +1336,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1291,13 +1377,17 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "repeat": "bucket",
       "repeatDirection": "v",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "topk(3, sum by (bucket) (kv_collection_mem_used_bytes{cluster=`$cluster`,bucket=~`${bucket:regex}`}))",
+          "expr": "topk(3, sum by (bucket) (kv_collection_mem_used_bytes{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "interval": "",
           "legendFormat": "{{ bucket }}",
           "refId": "A"
@@ -1307,17 +1397,15 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 68
       },
       "id": 10,
       "panels": [
         {
-          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1368,7 +1456,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 47
+            "y": 69
           },
           "id": 14,
           "options": {
@@ -1384,8 +1472,12 @@
           "pluginVersion": "8.2.7",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
-              "expr": "sum (kv_dcp_items_remaining{cluster=`$cluster`,connection_type!=\"\"}) by (connection_type)",
+              "expr": "sum (kv_dcp_items_remaining{cluster_name=~\"$cluster\",connection_type!=\"\"}) by (connection_type)",
               "interval": "",
               "legendFormat": "{{ connection_type }}",
               "refId": "A"
@@ -1395,7 +1487,6 @@
           "type": "timeseries"
         },
         {
-          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1451,7 +1542,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 47
+            "y": 69
           },
           "id": 16,
           "options": {
@@ -1466,8 +1557,12 @@
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
-              "expr": "sum by (connection_type) (irate(kv_dcp_items_sent{cluster=`$cluster`,connection_type!=\"\"}[$__rate_interval]))",
+              "expr": "sum by (connection_type) (irate(kv_dcp_items_sent{cluster_name=~\"$cluster\",connection_type!=\"\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{ connection_type }}",
               "refId": "A"
@@ -1477,7 +1572,6 @@
           "type": "timeseries"
         },
         {
-          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1532,7 +1626,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 47
+            "y": 69
           },
           "id": 12,
           "options": {
@@ -1547,8 +1641,12 @@
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
-              "expr": "sum by (bucket, connection_type) (kv_dcp_backoff{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+              "expr": "sum by (bucket, connection_type) (kv_dcp_backoff{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
               "interval": "",
               "legendFormat": "{{bucket}} ({{connection_type}})",
               "refId": "A"
@@ -1563,7 +1661,7 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 32,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [
     "couchbase",
@@ -1574,12 +1672,8 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": null,
-        "definition": "label_values(multimanager_cluster_checker_status,cluster_name)",
-        "description": null,
-        "error": null,
+        "definition": "label_values(kv_curr_items,cluster_name)",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
@@ -1587,30 +1681,19 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_cluster_checker_status,cluster_name)",
+          "query": "label_values(kv_curr_items,cluster_name)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 3,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       },
       {
-        "allValue": null,
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": null,
-        "definition": "label_values(multimanager_bucket_checker_status,bucket)",
-        "description": null,
-        "error": null,
+        "current": {},
+        "definition": "label_values(kv_curr_items,bucket)",
         "hide": 0,
         "includeAll": true,
         "label": "Bucket",
@@ -1618,22 +1701,19 @@
         "name": "bucket",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_bucket_checker_status,bucket)",
+          "query": "label_values(kv_curr_items,bucket)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": null,
-        "definition": "query_result(max by (cluster_uuid) (multimanager_cluster_checker_status{cluster_name=${cluster:doublequote}}))",
-        "description": null,
-        "error": null,
+        "definition": "label_values(multimanager_cluster_checker_status{cluster_name=~\"$cluster\"}, cluster_uuid)",
         "hide": 2,
         "includeAll": false,
         "label": "",
@@ -1641,14 +1721,15 @@
         "name": "cluster_uuid",
         "options": [],
         "query": {
-          "query": "query_result(max by (cluster_uuid) (multimanager_cluster_checker_status{cluster_name=${cluster:doublequote}}))",
+          "query": "label_values(multimanager_cluster_checker_status{cluster_name=~\"$cluster\"}, cluster_uuid)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/[{,]cluster_uuid=\"(.+?)\"[,}]/",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       }
     ]
   },
@@ -1672,5 +1753,6 @@
   "timezone": "",
   "title": "Data Service",
   "uid": "4vnZHfcnk",
-  "version": 10
+  "version": 5,
+  "weekStart": ""
 }

--- a/microlith/grafana/provisioning/dashboards/service-eventing.json
+++ b/microlith/grafana/provisioning/dashboards/service-eventing.json
@@ -1,4 +1,41 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.3.4"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -20,10 +57,9 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": null,
   "graphTooltip": 0,
-  "id": 6,
-  "iteration": 1639668303329,
+  "id": null,
+  "iteration": 1645036424975,
   "links": [
     {
       "asDropdown": false,
@@ -77,7 +113,6 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -118,11 +153,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum(group by (functionName) (eventing_agg_queue_size{cluster=`$cluster`}))",
+          "expr": "sum(group by (functionName) (eventing_agg_queue_size{cluster_name=~\"$cluster\"}))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -132,7 +171,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "description": "This is in the past time range, i.e., the value set in the top-right corner of \"Last X time unit\" (defaults to 30 minutes).",
       "fieldConfig": {
         "defaults": {
@@ -175,26 +213,38 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "round(sum(increase(eventing_on_update_failure{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__range])))",
+          "expr": "round(sum(increase(eventing_on_update_failure{cluster_name=~\"$cluster\",functionName=~\"$func_name\"}[$__range])))",
           "interval": "",
           "legendFormat": "Update",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "round(sum(increase(eventing_on_delete_failure{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__range])))",
+          "expr": "round(sum(increase(eventing_on_delete_failure{cluster_name=~\"$cluster\",functionName=~\"$func_name\"}[$__range])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Delete",
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "round(sum(increase(eventing_timeout_count{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__range])))",
+          "expr": "round(sum(increase(eventing_timeout_count{cluster_name=~\"$cluster\",functionName=~\"$func_name\"}[$__range])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Timeout",
@@ -206,7 +256,6 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -219,7 +268,6 @@
       "type": "row"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -286,8 +334,12 @@
       "pluginVersion": "8.2.7",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum by (functionName) (eventing_agg_queue_size{cluster=`$cluster`,functionName=~`^${function:regex}$`})",
+          "expr": "sum by (functionName) (eventing_agg_queue_size{cluster_name=~\"$cluster\",functionName=~\"$func_name\"})",
           "interval": "",
           "legendFormat": "{{ functionName }}",
           "refId": "A"
@@ -297,7 +349,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -365,8 +416,12 @@
       "pluginVersion": "8.2.7",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum by (functionName) (eventing_agg_queue_memory{cluster=`$cluster`,functionName=~`^${function:regex}$`})",
+          "expr": "sum by (functionName) (eventing_agg_queue_memory{cluster_name=~\"$cluster\",functionName=~\"$func_name\"})",
           "interval": "",
           "legendFormat": "{{ functionName }}",
           "refId": "A"
@@ -376,7 +431,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -443,15 +497,23 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "irate(eventing_on_update_success{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__rate_interval])",
+          "expr": "irate(eventing_on_update_success{cluster_name=~\"$cluster\",functionName=~\"$func_name\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{functionName}} Update",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "irate(eventing_on_delete_success{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__rate_interval])",
+          "expr": "irate(eventing_on_delete_success{cluster_name=~\"$cluster\",functionName=~\"$func_name\"}[$__rate_interval])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{functionName}} Delete",
@@ -462,7 +524,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -529,21 +590,33 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "irate(eventing_on_update_failure{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__rate_interval])",
+          "expr": "irate(eventing_on_update_failure{cluster_name=~\"$cluster\",functionName=~\"$func_name\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{functionName}} Update",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "irate(eventing_on_delete_failure{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__rate_interval])",
+          "expr": "irate(eventing_on_delete_failure{cluster_name=~\"$cluster\",functionName=~\"$func_name\"}[$__rate_interval])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{functionName}} Delete",
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
           "expr": "irate(eventing_timeout_count{cluster=`$cluster`,functionName=~`^${function:regex}$`}[$__rate_interval])",
           "hide": false,
@@ -557,7 +630,7 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 32,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [
     "couchbase",
@@ -568,58 +641,43 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": null,
-        "definition": "label_values(multimanager_cluster_checker_status,cluster_name)",
-        "description": null,
-        "error": null,
+        "definition": "label_values(eventing_on_update_success,cluster_name)",
         "hide": 0,
         "includeAll": false,
-        "label": null,
         "multi": false,
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_cluster_checker_status,cluster_name)",
+          "query": "label_values(eventing_on_update_success,cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       },
       {
-        "allValue": null,
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": null,
-        "definition": "query_result(present_over_time(eventing_on_update_success{cluster=`$cluster`}[$__range]))",
-        "description": null,
-        "error": null,
+        "current": {},
+        "definition": "label_values(eventing_on_update_success{cluster_name=~\"$cluster\"},functionName)",
         "hide": 0,
         "includeAll": true,
         "label": "Function",
         "multi": true,
-        "name": "function",
+        "name": "func_name",
         "options": [],
         "query": {
-          "query": "query_result(present_over_time(eventing_on_update_success{cluster=`$cluster`}[$__range]))",
+          "query": "label_values(eventing_on_update_success{cluster_name=~\"$cluster\"},functionName)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/[{,]functionName=\"(.+?)\"/",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       }
     ]
   },
@@ -643,5 +701,6 @@
   "timezone": "",
   "title": "Eventing Service",
   "uid": "R0hxsR2nk",
-  "version": 14
+  "version": 2,
+  "weekStart": ""
 }

--- a/microlith/grafana/provisioning/dashboards/service-index.json
+++ b/microlith/grafana/provisioning/dashboards/service-index.json
@@ -1,4 +1,53 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.3.4"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -20,10 +69,9 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1638372982203,
+  "id": null,
+  "iteration": 1645036831247,
   "links": [
     {
       "asDropdown": false,
@@ -77,7 +125,6 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -120,11 +167,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "count(count by (bucket, scope, collection, index) (index_resident_percent{cluster=`$cluster`, bucket=~`${bucket:regex}`}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "count(count by (bucket, scope, collection, index) (index_resident_percent{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -135,7 +186,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -177,11 +227,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum(index_items_count{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "sum(index_items_count{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -193,7 +247,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -209,7 +262,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -235,11 +288,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum(index_memory_used{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "sum(index_memory_used{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{instance}}",
@@ -250,7 +307,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -266,7 +322,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -292,11 +348,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum(index_data_size_on_disk{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "sum(index_data_size_on_disk{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{instance}}",
@@ -307,7 +367,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "description": "Indexes that have never been scanned and may be redundant.",
       "fieldConfig": {
         "defaults": {
@@ -374,14 +433,25 @@
       },
       "id": 8,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "(sum by (bucket, scope, collection, index) (index_num_requests{cluster=`$cluster`,bucket=~`${bucket:regex}`})) == 0",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "(sum by (bucket, scope, collection, index) (index_num_requests{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})) == 0",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -418,7 +488,6 @@
       "type": "table"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -488,8 +557,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "rate(index_num_requests{cluster=`$cluster`,bucket=~`${bucket:regex}`}[$__rate_interval])",
+          "expr": "rate(index_num_requests{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "{{index}}",
@@ -500,7 +573,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -566,8 +638,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum(index_num_docs_pending{cluster=`$cluster`,bucket=~`${bucket:regex}`}) by (index)",
+          "expr": "sum(index_num_docs_pending{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}) by (index)",
           "interval": "",
           "legendFormat": "{{index}}",
           "refId": "A"
@@ -577,7 +653,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -617,11 +692,15 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "topk(5, index_data_size{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "topk(5, index_data_size{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{bucket}} / {{index}}",
@@ -632,7 +711,6 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -672,11 +750,15 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "topk(5, sum by (bucket, index) (index_avg_scan_latency{cluster=`$cluster`,bucket=~`${bucket:regex}`}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "topk(5, sum by (bucket, index) (index_avg_scan_latency{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -689,7 +771,7 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 32,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [
     "couchbase",
@@ -700,12 +782,8 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": null,
-        "definition": "label_values(multimanager_cluster_checker_status,cluster_name)",
-        "description": null,
-        "error": null,
+        "definition": "label_values(index_memory_quota,cluster_name)",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
@@ -713,30 +791,19 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_cluster_checker_status,cluster_name)",
+          "query": "label_values(index_memory_quota,cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       },
       {
-        "allValue": null,
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": null,
-        "definition": "label_values(multimanager_bucket_checker_status,bucket)",
-        "description": null,
-        "error": null,
+        "current": {},
+        "definition": "label_values(index_num_requests{cluster_name=~\"$cluster\"},bucket)",
         "hide": 0,
         "includeAll": true,
         "label": "Bucket",
@@ -744,14 +811,15 @@
         "name": "bucket",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_bucket_checker_status,bucket)",
+          "query": "label_values(index_num_requests{cluster_name=~\"$cluster\"},bucket)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       }
     ]
   },
@@ -775,5 +843,6 @@
   "timezone": "",
   "title": "Index Service",
   "uid": "zlHletp7k",
-  "version": 3
+  "version": 2,
+  "weekStart": ""
 }

--- a/microlith/grafana/provisioning/dashboards/service-query.json
+++ b/microlith/grafana/provisioning/dashboards/service-query.json
@@ -1,4 +1,41 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.3.4"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -20,10 +57,9 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1638367099980,
+  "id": null,
+  "iteration": 1645037455645,
   "links": [
     {
       "asDropdown": false,
@@ -77,7 +113,6 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -122,11 +157,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum(irate(n1ql_warnings{cluster=`$cluster`}[$__rate_interval]))",
+          "expr": "sum(irate(n1ql_warnings{cluster_name=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -136,7 +175,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -204,8 +242,12 @@
       "pluginVersion": "8.2.7",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "irate(n1ql_errors{cluster=`$cluster`}[$__rate_interval])",
+          "expr": "irate(n1ql_errors{cluster_name=~\"$cluster\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{instance}} (last $__interval)",
           "refId": "A"
@@ -215,7 +257,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "description": "This is in the past time range, i.e., the value set in the top-right corner of \"Last X time unit\" (defaults to 30 minutes).",
       "fieldConfig": {
         "defaults": {
@@ -232,7 +273,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "short"
         },
         "overrides": [
           {
@@ -367,11 +408,15 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "round(sum(increase(n1ql_requests_250ms{cluster=`$cluster`}[$__range])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "round(sum(increase(n1ql_requests_250ms{cluster_name=~\"$cluster\"}[$__range])))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -380,8 +425,12 @@
           "refId": "B"
         },
         {
-          "exemplar": true,
-          "expr": "round(sum(increase(n1ql_requests_500ms{cluster=`$cluster`}[$__range])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "round(sum(increase(n1ql_requests_500ms{cluster_name=~\"$cluster\"}[$__range])))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -389,16 +438,24 @@
           "refId": "D"
         },
         {
-          "exemplar": true,
-          "expr": "round(sum(increase(n1ql_requests_1000ms{cluster=`$cluster`}[$__range])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "round(sum(increase(n1ql_requests_1000ms{cluster_name=~\"$cluster\"}[$__range])))",
           "instant": true,
           "interval": "",
           "legendFormat": "1000ms",
           "refId": "A"
         },
         {
-          "exemplar": true,
-          "expr": "round(sum(increase(n1ql_requests_5000ms{cluster=`$cluster`}[$__range])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "round(sum(increase(n1ql_requests_5000ms{cluster_name=~\"$cluster\"}[$__range])))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -411,7 +468,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -478,8 +534,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "irate(n1ql_requests{cluster=`$cluster`}[$__rate_interval])",
+          "expr": "irate(n1ql_requests{cluster_name=~\"$cluster\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -489,7 +549,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -556,8 +615,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "rate(n1ql_request_time{cluster=`$cluster`}[$__rate_interval]) / rate(n1ql_requests{cluster=`$cluster`}[$__rate_interval])",
+          "expr": "rate(n1ql_request_time{cluster_name=~\"$cluster\"}[$__rate_interval]) / rate(n1ql_requests{cluster_name=~\"$cluster\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -568,7 +631,7 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 32,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [
     "couchbase",
@@ -579,12 +642,8 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": null,
-        "definition": "label_values(multimanager_cluster_checker_status,cluster_name)",
-        "description": null,
-        "error": null,
+        "definition": "label_values(n1ql_requests,cluster_name)",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
@@ -592,14 +651,15 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_cluster_checker_status,cluster_name)",
+          "query": "label_values(n1ql_requests,cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       }
     ]
   },
@@ -623,5 +683,6 @@
   "timezone": "",
   "title": "Query Service",
   "uid": "89ydpf5nz",
-  "version": 17
+  "version": 3,
+  "weekStart": ""
 }

--- a/microlith/grafana/provisioning/dashboards/service-search.json
+++ b/microlith/grafana/provisioning/dashboards/service-search.json
@@ -1,4 +1,53 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.3.4"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -20,10 +69,9 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": null,
   "graphTooltip": 0,
-  "id": 9,
-  "iteration": 1638372719808,
+  "id": null,
+  "iteration": 1645037688290,
   "links": [
     {
       "asDropdown": false,
@@ -77,7 +125,6 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -118,11 +165,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "count(count by (bucket, scope, collection, index) (fts_doc_count{cluster=`$cluster`,bucket=~`${bucket:regex}`}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "count(count by (bucket, scope, collection, index) (fts_doc_count{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -133,7 +184,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -175,11 +225,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "sum(fts_doc_count{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "expr": "sum(fts_doc_count{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -191,7 +245,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -207,7 +260,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -233,11 +286,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum(fts_num_bytes_used_ram{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "sum(fts_num_bytes_used_ram{cluster_name=~\"$cluster\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -248,7 +305,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -264,7 +320,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbits"
         },
         "overrides": []
       },
@@ -290,11 +346,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sum(fts_num_bytes_used_disk{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "sum(fts_num_bytes_used_disk{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -305,7 +365,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
       "description": "Indexes that have never been scanned and may be redundant.",
       "fieldConfig": {
         "defaults": {
@@ -372,14 +431,25 @@
       },
       "id": 8,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "(sum by (bucket, scope, collection, index) (fts_total_queries{cluster=`$cluster`,bucket=~`${bucket:regex}`})) == 0",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "(sum by (bucket, scope, collection, index) (fts_total_queries{cluster_name=~\"$cluster\",bucket=~\"$bucket\"})) == 0",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -416,7 +486,6 @@
       "type": "table"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -487,8 +556,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "topk(5, sum by (bucket, index) (rate(fts_total_queries{cluster=`$cluster`,bucket=~`${bucket:regex}`}[$__rate_interval])))",
+          "expr": "topk(5, sum by (bucket, index) (rate(fts_total_queries{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}[$__rate_interval])))",
           "interval": "",
           "legendFormat": "{{bucket}} / {{index}}",
           "refId": "A"
@@ -498,7 +571,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -545,7 +617,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
@@ -568,8 +641,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": true,
-          "expr": "fts_num_mutations_to_index{cluster=`$cluster`,bucket=~`${bucket:regex}`}",
+          "expr": "sum(fts_num_mutations_to_index{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}) by (bucket,index)",
           "interval": "",
           "legendFormat": "{{bucket}} / {{index}}",
           "refId": "A"
@@ -579,7 +656,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -595,7 +671,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbits"
         },
         "overrides": []
       },
@@ -619,11 +695,15 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "topk(5, fts_num_bytes_used_disk{cluster=`$cluster`,bucket=~`${bucket:regex}`})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "topk(5, sum by (bucket, index) (fts_num_bytes_used_disk{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "instant": true,
           "interval": "",
           "legendFormat": "{{bucket}} / {{index}}",
@@ -634,7 +714,6 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -650,7 +729,7 @@
               }
             ]
           },
-          "unit": "ns"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -674,11 +753,15 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "8.2.7",
+      "pluginVersion": "8.3.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "topk(5, sum by (bucket, index) (fts_avg_queries_latency{cluster=`$cluster`,bucket=~`${bucket:regex}`}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "topk(5, avg by (bucket, index) (fts_avg_queries_latency{cluster_name=~\"$cluster\",bucket=~\"$bucket\"}))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -691,7 +774,7 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 32,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [
     "couchbase",
@@ -702,12 +785,8 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": null,
-        "definition": "label_values(multimanager_cluster_checker_status,cluster_name)",
-        "description": null,
-        "error": null,
+        "definition": "label_values(fts_total_request_time,cluster_name)",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
@@ -715,30 +794,19 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_cluster_checker_status,cluster_name)",
+          "query": "label_values(fts_total_request_time,cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       },
       {
-        "allValue": null,
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": null,
-        "definition": "label_values(multimanager_bucket_checker_status,bucket)",
-        "description": null,
-        "error": null,
+        "current": {},
+        "definition": "label_values(fts_total_request_time{cluster_name=~\"$cluster\"},bucket)",
         "hide": 0,
         "includeAll": true,
         "label": "Bucket",
@@ -746,14 +814,15 @@
         "name": "bucket",
         "options": [],
         "query": {
-          "query": "label_values(multimanager_bucket_checker_status,bucket)",
+          "query": "label_values(fts_total_request_time{cluster_name=~\"$cluster\"},bucket)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}"
       }
     ]
   },
@@ -777,5 +846,6 @@
   "timezone": "",
   "title": "Search Service",
   "uid": "5O4ki2tnz",
-  "version": 9
+  "version": 2,
+  "weekStart": ""
 }


### PR DESCRIPTION
- Derive variables from relevant cluster metrics not multimanager
- Removed :doublequote / quote references and used standard syntax
- Normalized label references the `cluster_name` label was used to set $cluster, but labels in panel queries used cluster=`$cluster` and it should be cluster_name=~”$cluster”

Resolves CMOS-326