### PR TITLE
CMOS-338: Replace all checker docs links with public site

### DIFF
--- a/microlith/grafana/provisioning/dashboards/bucket-overview.json
+++ b/microlith/grafana/provisioning/dashboards/bucket-overview.json
@@ -209,7 +209,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }

--- a/microlith/grafana/provisioning/dashboards/cluster-overview.json
+++ b/microlith/grafana/provisioning/dashboards/cluster-overview.json
@@ -1766,7 +1766,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -1784,7 +1784,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2011,7 +2011,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2046,7 +2046,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checkers Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2272,7 +2272,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2308,7 +2308,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }

--- a/microlith/grafana/provisioning/dashboards/node-overview.json
+++ b/microlith/grafana/provisioning/dashboards/node-overview.json
@@ -489,7 +489,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checkers Info",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -507,7 +507,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checkers Info",
-                    "url": "/public/cmos-doc-redirect.html#/docs/cmos/0.1/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }


### PR DESCRIPTION
Ensure we link to somewhere they'll be accessible even if the dashboards are installed outside the microlith.