### PR TITLE
CMOS-352: Dashboards: replace all references to docs-staging.couchbase with docs.couchbase

### DIFF
--- a/microlith/grafana/provisioning/dashboards/bucket-overview.json
+++ b/microlith/grafana/provisioning/dashboards/bucket-overview.json
@@ -209,7 +209,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }

--- a/microlith/grafana/provisioning/dashboards/cluster-overview.json
+++ b/microlith/grafana/provisioning/dashboards/cluster-overview.json
@@ -1778,7 +1778,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -1796,7 +1796,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2023,7 +2023,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2058,7 +2058,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checkers Documentation",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2284,7 +2284,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -2320,7 +2320,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checker Documentation",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }

--- a/microlith/grafana/provisioning/dashboards/node-overview.json
+++ b/microlith/grafana/provisioning/dashboards/node-overview.json
@@ -489,7 +489,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checkers Info",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }
@@ -507,7 +507,7 @@
                   {
                     "targetBlank": true,
                     "title": "Checkers Info",
-                    "url": "https://docs-staging.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
+                    "url": "https://docs.couchbase.com/cmos/current/health-checks.html#${__data.fields.ID}"
                   }
                 ]
               }


### PR DESCRIPTION
This isn't live yet, but will be necessary once the public DP is released. Once that's done and we've branched for release, we can likely revert it back on `main` which will track latest docs.