### PR TITLE
CMOS-353: Remove agent details from docs

### DIFF
--- a/docs/modules/ROOT/pages/integrating-with-existing-deployments.adoc
+++ b/docs/modules/ROOT/pages/integrating-with-existing-deployments.adoc
@@ -24,12 +24,8 @@ The environment you wish to integrate CMOS into must have:
 
 === Install Cluster Monitor
 
-The Cluster Monitor can be installed by downloading a Docker image.
-
-[NOTE]
-====
-We plan for the image to be distributed on Docker Hub, but currently this is not available. 
-====
+Currently there is no separate image containing just the Cluster Monitor - you can follow issue https://issues.couchbase.com/browse/CMOS-351[CMOS-351^] for updates on this option.
+However, it is possible to use the main CMOS container with all other services disabled for this purpose.
 
 Run the Docker container, using the preview image given to you by Couchbase:
 [source, console]
@@ -39,15 +35,18 @@ docker run -d --rm \
   -e CB_MULTI_ALERTMANAGER_URLS=http://<Alertmanager IP>:9093 \ <.> 
   -e CB_MULTI_ADMIN_USER=admin -e CB_MULTI_ADMIN_PASSWORD=password \
   --name cluster_monitor \
-  <YOUR IMAGE HERE>
+  -e DISABLE_PROMETHEUS=true -e DISABLE_GRAFANA=true \
+  -e DISABLE_ALERT_MANAGER=true -e DISABLE_LOKI=true \
+  -e DISABLE_JAEGER=true -e DISABLE_CMOSCFG=true -e DISABLE_WEBSERVER=true \
+  couchbase/observability-stack:latest
 ----
 
 <.> If you are using TLS, you will need to add `-p 7197:7197` to also expose port `7197`.
-<.> This is not necessary if you are not using Alertmanager
+<.> If you are not using Alertmanager, set this to a blank value.
 
 [NOTE]
 ====
-Docker networking https://docs.docker.com/network/#network-drivers[defaults to bridge], meaning that this container will be able to communicate with any other running Docker containers.
+Docker networking https://docs.docker.com/network/#network-drivers[defaults to bridge^], meaning that this container will be able to communicate with any other running Docker containers.
 If your Grafana, Prometheus / Alertmanager instances are not containerized, ensure that the Cluster Monitor container can communicate with them.
 ====
 === Configure Cluster Monitor
@@ -57,11 +56,6 @@ Sign in using the credentials you provided as environment variables when you sta
 
 Then click "Add Cluster" and enter the IP address of a node in the cluster, along with the cluster's configured username and password.
 Repeat this for every cluster you wish to add to the Cluster Monitor.
-
-=== Install the Agent on your Couchbase Server nodes
-
-See https://issues.couchbase.com/browse/CMOS-210[CMOS-210], which tracks the development (including documentation) of the Agent.
-Until this is ready, follow the instructions given to you by your Couchbase representative.
 
 == Configuration
 
@@ -181,8 +175,8 @@ scrape_configs:
 <.> `username` should be set to a Couchbase Server user with at least "External Stats Reader" permission.
 <.> `password` should be the password of the above user.
 <.> `targets` should specify the addresses of all the nodes in your cluster.
-    The port number needs to be the management port: `8091` by default, or `:18091` if you have TLS enabled. 
-    Note that if you are not on Couchbase Server 7+, you should use the port that your chosen exporter uses - if this is `cbhealthagent` this will be `9092`.
+    For a Couchbase Server 7+ cluster the port number needs to be the management port: `8091` by default, or `:18091` if you have TLS enabled. 
+    For clusters below Couchbase Server 7.0, you should use the port that your Prometheus exporter uses.
     There are alternative configuration options that do not require hard-coding the addresses - refer to the https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config[Prometheus documentation^] for more details.
 <.> Any labels defined here will be added to **all** metrics from this cluster - you may want to configure e.g., `environment`, `datacenter` etc.
 


### PR DESCRIPTION
The intention is that this PR will be reverted once there is a separate 0.2.x branch for the live docs - this will ensure that the packaged docs in the container do not have references to the agent, nor will the docs.couchbase version, but the docs-staging.couchbase version will.