### PR TITLE
CBD-4609: Fix Trivy scans

### DIFF
--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -26,12 +26,13 @@ jobs:
 
             - name: Build an image from Dockerfile
               run: |
-                  make container-oss -e CMOS_IMAGE=couchbaselabs/observability-stack:${{ github.sha }}
+                make image-artifacts -e VERSION=0.0.0 -e BLD_NUM=999 -e OSS=true
+                tools/build-container-from-archive.sh dist/couchbase-observability-stack-image_0.0.0-999.tgz
 
             - name: Run Trivy vulnerability scanner
               uses: aquasecurity/trivy-action@master
               with:
-                  image-ref: couchbaselabs/observability-stack:${{ github.sha }}
+                  image-ref: couchbase/observability-stack:0.0.0-999
                   format: template
                   template: '@/contrib/sarif.tpl'
                   output: trivy-results.sarif


### PR DESCRIPTION
Action config was referencing a tag that no longer exists.