### PR TITLE
CMOS-395: Active vbuckets resident ratio checker

### DIFF
--- a/docs/modules/ROOT/partials/cmos-health-checks.adoc
+++ b/docs/modules/ROOT/partials/cmos-health-checks.adoc
@@ -299,10 +299,10 @@ If that is not possible, please contact Couchbase Technical Support.
 *Further Reading*: https://docs.couchbase.com/server/current/manage/manage-settings/configure-compact-settings.html[Auto-Compaction]
 
 [#CB90087]
-=== Active Vbucket Resident Ratio (CB90087)
-*Background*: Active vbucket Resident Ratio going below certain thresholds might lead to performance issues due to significant memory pressure.
+=== Active vBuckets Resident Ratio (CB90087)
+*Background*: Active vBuckets Resident Ratio going below certain thresholds might lead to performance issues due to significant memory pressure.
 
-*Condition*: Warn if Active vbucket Resident Ratio drops below 10 percent and alert if the same drops below 5 percent.
+*Condition*: Warn if Active vBuckets Resident Ratio drops below 10 percent and alert if the same drops below 5 percent.
 
 *Remediation*: Allocate sufficient memory for the bucket.
 

--- a/docs/modules/ROOT/partials/cmos-health-checks.adoc
+++ b/docs/modules/ROOT/partials/cmos-health-checks.adoc
@@ -300,10 +300,10 @@ If that is not possible, please contact Couchbase Technical Support.
 
 [#CB90087]
 === Active Vbucket Resident Ratio (CB90087)
-*Background*: Active Vbucket Resident Ratio going below certain thresholds might lead to performance issues due to significant memory pressure.
+*Background*: Active vbucket Resident Ratio going below certain thresholds might lead to performance issues due to significant memory pressure.
 
-*Condition*: Warn if Active Vbucket Resident Ratio drops below 10 percent and alert if the same drops below 5 percent.
+*Condition*: Warn if Active vbucket Resident Ratio drops below 10 percent and alert if the same drops below 5 percent.
 
-*Remidiation*: Allocate sufficient memory for the bucket.
+*Remediation*: Allocate sufficient memory for the bucket.
 
 // end::group-bucket[]

--- a/docs/modules/ROOT/partials/cmos-health-checks.adoc
+++ b/docs/modules/ROOT/partials/cmos-health-checks.adoc
@@ -302,7 +302,7 @@ If that is not possible, please contact Couchbase Technical Support.
 === Active vBuckets Resident Ratio (CB90087)
 *Background*: Active vBuckets Resident Ratio going below certain thresholds might lead to performance issues due to significant memory pressure.
 
-*Condition*: Warn if Active vBuckets Resident Ratio drops below 10 percent and alert if the same drops below 5 percent.
+*Condition*: By default, warn if Active vBuckets Resident Ratio drops below 10 percent and alert if the same drops below 5 percent.
 
 *Remediation*: Allocate sufficient memory for the bucket.
 

--- a/docs/modules/ROOT/partials/cmos-health-checks.adoc
+++ b/docs/modules/ROOT/partials/cmos-health-checks.adoc
@@ -298,4 +298,12 @@ If that is not possible, please contact Couchbase Technical Support.
 
 *Further Reading*: https://docs.couchbase.com/server/current/manage/manage-settings/configure-compact-settings.html[Auto-Compaction]
 
+[#CB90087]
+=== Active Vbucket Resident Ratio (CB90087)
+*Background*: Active Vbucket Resident Ratio going below certain thresholds might lead to performance issues due to significant memory pressure.
+
+*Condition*: Warn if Active Vbucket Resident Ratio drops below 10 percent and alert if the same drops below 5 percent.
+
+*Remidiation*: Allocate sufficient memory for the bucket.
+
 // end::group-bucket[]

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -197,7 +197,3 @@ groups:
       annotations:
         title: " Resident Ratio of Active Vbuckets too low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }}) "
         remediation: Increase memory allocation for bucket
-
-      
-
-

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -196,5 +196,5 @@ groups:
         severity: critical
       annotations:
         title: " Resident Ratio of Active vBuckets too low"
-        description: Resident Ratio of Active vBuckets is low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
+        description: Resident Ratio of Active vBuckets is too low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
         remediation: Increase memory allocation for bucket

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -166,7 +166,7 @@ groups:
         remediation: Ensure your applications are appropriately closing their Couchbase connections.
 
     - alert: CB90087-activeVbucketResidentRatio-warn
-      expr: kv_vb_perc_mem_resident_ratio{state="active"}  < 0.1
+      expr: kv_vb_perc_mem_resident_ratio{state="active"} < 0.1
       for: 1m
       labels:
         job: couchbase_prometheus
@@ -179,7 +179,7 @@ groups:
         severity: warning
       annotations:
         title: " Resident Ratio of Active vBuckets is low "
-        description: Resident Ratio of Active vBuckets is low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
+        description: Resident Ratio of Active vBuckets is low in bucket {{$labels.bucket}} on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
         remediation: Increase memory allocation for bucket
 
     - alert: CB90087-activeVbucketResidentRatio-alert
@@ -196,5 +196,5 @@ groups:
         severity: critical
       annotations:
         title: " Resident Ratio of Active vBuckets too low"
-        description: Resident Ratio of Active vBuckets is too low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
+        description: Resident Ratio of Active vBuckets is too low in bucket {{$labels.bucket}} on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
         remediation: Increase memory allocation for bucket

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -164,3 +164,40 @@ groups:
         description: Node {{ $labels.instance}} has {{ humanize $value }} open Data Service connections out of 60,000.
           Applications may fail to connect.
         remediation: Ensure your applications are appropriately closing their Couchbase connections.
+
+    - alert: CB90087-activeVbucketResidentRatio-warn
+      expr: kv_vb_perc_mem_resident_ratio{state="active"}  < 0.1
+      for: 1m
+      labels:
+        job: couchbase_prometheus
+        kind: bucket
+        health_check_id: CB90087
+        health_check_name: activeVbucketResidentRatio
+        cluster: '{{ $labels.cluster }}'
+        node: '{{ $labels.instance }}'
+        bucket: '{{ $labels.bucket }}'
+        severity: warning
+      annotations:
+        title: " Resident Ratio of Active Vbuckets is low in in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }}) "
+        description: 
+        remediation: Increase memory allocation for bucket
+
+    - alert: CB90087-activeVbucketResidentRatio-alert
+      expr: kv_vb_perc_mem_resident_ratio{state="active"} < 0.05
+      for: 1m
+      labels:
+        job: couchbase_prometheus
+        kind: bucket
+        health_check_id: CB90087
+        health_check_name: activeVbucketResidentRatio
+        cluster: '{{ $labels.cluster }}'
+        node: '{{ $labels.instance }}'
+        bucket: '{{ $labels.bucket }}'
+        severity: critical
+      annotations:
+        title: " Resident Ratio of Active Vbuckets too low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }}) "
+        remediation: Increase memory allocation for bucket
+
+      
+
+

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -178,8 +178,8 @@ groups:
         bucket: '{{ $labels.bucket }}'
         severity: warning
       annotations:
-        title: " Resident Ratio of Active Vbuckets is low in in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }}) "
-        description: 
+        title: " Resident Ratio of Active vBuckets is low "
+        description: Resident Ratio of Active vBuckets is low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
         remediation: Increase memory allocation for bucket
 
     - alert: CB90087-activeVbucketResidentRatio-alert
@@ -195,5 +195,6 @@ groups:
         bucket: '{{ $labels.bucket }}'
         severity: critical
       annotations:
-        title: " Resident Ratio of Active Vbuckets too low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }}) "
+        title: " Resident Ratio of Active vBuckets too low"
+        description: Resident Ratio of Active vBuckets is low in bucket {{$labels.bucket}}  on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
         remediation: Increase memory allocation for bucket

--- a/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
+++ b/microlith/prometheus/alerting/couchbase/couchbase-rules.yaml
@@ -178,9 +178,9 @@ groups:
         bucket: '{{ $labels.bucket }}'
         severity: warning
       annotations:
-        title: " Resident Ratio of Active vBuckets is low "
-        description: Resident Ratio of Active vBuckets is low in bucket {{$labels.bucket}} on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
-        remediation: Increase memory allocation for bucket
+        title: "Resident Ratio of Active vBuckets is low."
+        description: Resident Ratio of Active vBuckets is low in bucket {{$labels.bucket}} on node - {{$labels.instance}} (cluster {{ $labels.cluster }}).
+        remediation: Increase memory allocation for bucket.
 
     - alert: CB90087-activeVbucketResidentRatio-alert
       expr: kv_vb_perc_mem_resident_ratio{state="active"} < 0.05
@@ -195,6 +195,6 @@ groups:
         bucket: '{{ $labels.bucket }}'
         severity: critical
       annotations:
-        title: " Resident Ratio of Active vBuckets too low"
-        description: Resident Ratio of Active vBuckets is too low in bucket {{$labels.bucket}} on node - {{$labels.instance}} (cluster {{ $labels.cluster }})
-        remediation: Increase memory allocation for bucket
+        title: "Resident Ratio of Active vBuckets too low."
+        description: Resident Ratio of Active vBuckets is too low in bucket {{$labels.bucket}} on node - {{$labels.instance}} (cluster {{ $labels.cluster }}).
+        remediation: Increase memory allocation for bucket.


### PR DESCRIPTION
Checker to alert and warn when active vbucket resident ratio in memory drops below a threshold (warning below 10 percent and alert below 5 percent)

<img width="1458" alt="Screenshot 2022-04-18 at 10 54 24 AM" src="https://user-images.githubusercontent.com/39858842/163759251-e03ac925-5d4e-4cb0-be56-a7524ef6ba6a.png">
