### PR TITLE
CMOS-425: Updated nginx config for multimanager UI

### DIFF
--- a/microlith/nginx/nginx.conf.tmpl
+++ b/microlith/nginx/nginx.conf.tmpl
@@ -75,13 +75,9 @@ http {
 
             # TODO (CMOS-98) - eventually these should all just be /couchbase/
 
-            # Redirect /ui to its proper place just in case
-            location ~ ^{{ $subPath }}/ui/?$ {
-                return 301 {{ $subPath }}/couchbase/ui;
-            }
 
-            location {{ $subPath }}/couchbase/ui/ {
-                proxy_pass http://localhost:7196/couchbase/ui;
+            location {{ $subPath }}/monitor {
+                proxy_pass http://localhost:7196/monitor;
             }
 
             # UI assumes the cbmultimanager REST API is on /api

--- a/microlith/nginx/nginx.conf.tmpl
+++ b/microlith/nginx/nginx.conf.tmpl
@@ -80,16 +80,14 @@ http {
                 return 301 {{ $subPath }}/couchbase/ui;
             }
 
-            # Static assets are served here and there's no easy way to change it
-            location {{ $subPath }}/ui/assets/ {
-                proxy_pass  http://localhost:7196;
+            location {{ $subPath }}/couchbase/ui/ {
+                proxy_pass http://localhost:7196/couchbase/ui;
             }
 
             # UI assumes the cbmultimanager REST API is on /api
             location {{ $subPath }}/api/ {
                 # cbmm doesn't yet support path prefixes so strip it
-                rewrite ^{{ $subPath }}/api(.*)$ /api$1;
-                proxy_pass  http://localhost:7196;
+                proxy_pass  http://localhost:7196/api/;
             }
 
             location {{ $subPath }}/couchbase {


### PR DESCRIPTION
Multimanager UI sits on /couchbase/ui not /ui
This simplifies the required NGINX config