### PR TITLE
CMOS-514: Remove nsswitch directory change as issue is fixed in new loki version

### DIFF
--- a/docs/modules/ROOT/pages/licensing.adoc
+++ b/docs/modules/ROOT/pages/licensing.adoc
@@ -167,9 +167,6 @@ RUN addgroup -g 10001 -S loki && \
     mkdir -p /loki/rules-temp && \
     chown -R loki:loki /etc/loki /loki
 
-# See https://github.com/grafana/loki/issues/1928
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-
 EXPOSE 3100
 # USER loki
 ----


### PR DESCRIPTION
Remove the fix that was added for https://github.com/grafana/loki/issues/1928 as we have upgraded the loki version.